### PR TITLE
Fix MultiMonitorTool GUI popup, add integration tests

### DIFF
--- a/HaPcRemote.sln
+++ b/HaPcRemote.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -14,6 +14,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HaPcRemote.Service.Tests", "tests\HaPcRemote.Service.Tests\HaPcRemote.Service.Tests.csproj", "{355646D7-EB4C-4D94-BF33-FC0197168016}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HaPcRemote.IntegrationTests", "tests\HaPcRemote.IntegrationTests\HaPcRemote.IntegrationTests.csproj", "{475DCCBA-E1DB-439C-971E-3EFE922E6AD7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -73,6 +75,18 @@ Global
 		{355646D7-EB4C-4D94-BF33-FC0197168016}.Release|x64.Build.0 = Release|Any CPU
 		{355646D7-EB4C-4D94-BF33-FC0197168016}.Release|x86.ActiveCfg = Release|Any CPU
 		{355646D7-EB4C-4D94-BF33-FC0197168016}.Release|x86.Build.0 = Release|Any CPU
+		{475DCCBA-E1DB-439C-971E-3EFE922E6AD7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{475DCCBA-E1DB-439C-971E-3EFE922E6AD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{475DCCBA-E1DB-439C-971E-3EFE922E6AD7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{475DCCBA-E1DB-439C-971E-3EFE922E6AD7}.Debug|x64.Build.0 = Debug|Any CPU
+		{475DCCBA-E1DB-439C-971E-3EFE922E6AD7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{475DCCBA-E1DB-439C-971E-3EFE922E6AD7}.Debug|x86.Build.0 = Debug|Any CPU
+		{475DCCBA-E1DB-439C-971E-3EFE922E6AD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{475DCCBA-E1DB-439C-971E-3EFE922E6AD7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{475DCCBA-E1DB-439C-971E-3EFE922E6AD7}.Release|x64.ActiveCfg = Release|Any CPU
+		{475DCCBA-E1DB-439C-971E-3EFE922E6AD7}.Release|x64.Build.0 = Release|Any CPU
+		{475DCCBA-E1DB-439C-971E-3EFE922E6AD7}.Release|x86.ActiveCfg = Release|Any CPU
+		{475DCCBA-E1DB-439C-971E-3EFE922E6AD7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -82,5 +96,6 @@ Global
 		{B1C2D3E4-F5A6-47B8-9C0D-1E2F3A4B5C6D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{C2D3E4F5-A6B7-48C9-0D1E-2F3A4B5C6D7E} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{355646D7-EB4C-4D94-BF33-FC0197168016} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{475DCCBA-E1DB-439C-971E-3EFE922E6AD7} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/HaPcRemote.Service/Services/MonitorService.cs
+++ b/src/HaPcRemote.Service/Services/MonitorService.cs
@@ -53,8 +53,17 @@ public class MonitorService
 
     public async Task<List<MonitorInfo>> GetMonitorsAsync()
     {
-        var output = await _cliRunner.RunAsync(GetExePath(), ["/scomma", ""]);
-        return ParseCsvOutput(output);
+        var tempFile = Path.Combine(Path.GetTempPath(), $"mmt_{Guid.NewGuid():N}.csv");
+        try
+        {
+            await _cliRunner.RunAsync(GetExePath(), ["/scomma", tempFile]);
+            var output = await File.ReadAllTextAsync(tempFile);
+            return ParseCsvOutput(output);
+        }
+        finally
+        {
+            try { File.Delete(tempFile); } catch { /* best-effort cleanup */ }
+        }
     }
 
     public async Task EnableMonitorAsync(string id)

--- a/tests/HaPcRemote.IntegrationTests/AppEndpointTests.cs
+++ b/tests/HaPcRemote.IntegrationTests/AppEndpointTests.cs
@@ -1,0 +1,67 @@
+using HaPcRemote.IntegrationTests.Models;
+using Shouldly;
+
+namespace HaPcRemote.IntegrationTests;
+
+public class AppEndpointTests : IntegrationTestBase
+{
+    [Fact]
+    [Trait("Category", "ReadOnly")]
+    public async Task GetStatuses_ReturnsList()
+    {
+        var response = await GetAsync<List<AppInfo>>("/api/app/status");
+
+        response.Success.ShouldBeTrue();
+        response.Data.ShouldNotBeNull();
+        // May be empty if no apps are configured
+    }
+
+    [Fact]
+    [Trait("Category", "ReadOnly")]
+    public async Task GetStatus_InvalidApp_Returns404()
+    {
+        var response = await GetRawAsync("/api/app/status/nonexistent123");
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    [Trait("Category", "Mutating")]
+    public async Task LaunchApp_InvalidApp_Returns404()
+    {
+        var response = await PostRawAsync("/api/app/launch/nonexistent123");
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    [Trait("Category", "Mutating")]
+    public async Task KillApp_InvalidApp_Returns404()
+    {
+        var response = await PostRawAsync("/api/app/kill/nonexistent123");
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    [Trait("Category", "ReadOnly")]
+    public async Task GetStatus_ValidApp_ReturnsAppInfo()
+    {
+        var all = await GetAsync<List<AppInfo>>("/api/app/status");
+        all.Data.ShouldNotBeNull();
+
+        if (all.Data.Count == 0)
+        {
+            // No apps configured — skip gracefully
+            return;
+        }
+
+        var firstKey = all.Data.First().Key;
+        var response = await GetAsync<AppInfo>($"/api/app/status/{firstKey}");
+
+        response.Success.ShouldBeTrue();
+        response.Data.ShouldNotBeNull();
+        response.Data.Key.ShouldBe(firstKey);
+        response.Data.DisplayName.ShouldNotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/HaPcRemote.IntegrationTests/AudioEndpointTests.cs
+++ b/tests/HaPcRemote.IntegrationTests/AudioEndpointTests.cs
@@ -1,0 +1,110 @@
+using HaPcRemote.IntegrationTests.Models;
+using Shouldly;
+
+namespace HaPcRemote.IntegrationTests;
+
+public class AudioEndpointTests : IntegrationTestBase
+{
+    [Fact]
+    [Trait("Category", "ReadOnly")]
+    public async Task GetDevices_ReturnsDeviceList()
+    {
+        var response = await GetAsync<List<AudioDevice>>("/api/audio/devices");
+
+        response.Success.ShouldBeTrue();
+        response.Data.ShouldNotBeNull();
+        response.Data.ShouldNotBeEmpty();
+
+        var first = response.Data.First();
+        first.Name.ShouldNotBeNullOrWhiteSpace();
+        first.Volume.ShouldBeInRange(0, 100);
+    }
+
+    [Fact]
+    [Trait("Category", "ReadOnly")]
+    public async Task GetDevices_HasDefaultDevice()
+    {
+        var response = await GetAsync<List<AudioDevice>>("/api/audio/devices");
+
+        response.Data.ShouldNotBeNull();
+        response.Data.ShouldContain(d => d.IsDefault);
+    }
+
+    [Fact]
+    [Trait("Category", "ReadOnly")]
+    public async Task GetCurrent_ReturnsDefaultDevice()
+    {
+        var response = await GetAsync<AudioDevice>("/api/audio/current");
+
+        response.Success.ShouldBeTrue();
+        response.Data.ShouldNotBeNull();
+        response.Data.Name.ShouldNotBeNullOrWhiteSpace();
+        response.Data.Volume.ShouldBeInRange(0, 100);
+    }
+
+    [Fact]
+    [Trait("Category", "Mutating")]
+    public async Task SetVolume_ValidLevel_ReturnsOk()
+    {
+        var response = await PostAsync("/api/audio/volume/50");
+
+        response.Success.ShouldBeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Mutating")]
+    public async Task SetVolume_TooHigh_Returns400()
+    {
+        var response = await PostRawAsync("/api/audio/volume/101");
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Mutating")]
+    public async Task SetVolume_TooLow_Returns400()
+    {
+        var response = await PostRawAsync("/api/audio/volume/-1");
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Mutating")]
+    public async Task SetVolume_PreservesLevel()
+    {
+        // Set volume to 42
+        var setResponse = await PostAsync("/api/audio/volume/42");
+        setResponse.Success.ShouldBeTrue();
+
+        // Read it back
+        var current = await GetAsync<AudioDevice>("/api/audio/current");
+        current.Data.ShouldNotBeNull();
+        current.Data.Volume.ShouldBe(42);
+    }
+
+    [Fact]
+    [Trait("Category", "Mutating")]
+    public async Task SetDefaultDevice_ValidDevice_ReturnsOk()
+    {
+        // Get list of devices, pick one
+        var devices = await GetAsync<List<AudioDevice>>("/api/audio/devices");
+        devices.Data.ShouldNotBeNull();
+        devices.Data.ShouldNotBeEmpty();
+
+        var device = devices.Data.First();
+        var encodedName = Uri.EscapeDataString(device.Name);
+
+        var response = await PostAsync($"/api/audio/set/{encodedName}");
+        response.Success.ShouldBeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Mutating")]
+    public async Task SetDefaultDevice_InvalidDevice_Returns500()
+    {
+        var response = await PostRawAsync("/api/audio/set/NonexistentDevice123");
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.InternalServerError);
+    }
+}

--- a/tests/HaPcRemote.IntegrationTests/AuthTests.cs
+++ b/tests/HaPcRemote.IntegrationTests/AuthTests.cs
@@ -1,0 +1,33 @@
+using Shouldly;
+
+namespace HaPcRemote.IntegrationTests;
+
+[Trait("Category", "ReadOnly")]
+public class AuthTests : IntegrationTestBase
+{
+    [Fact]
+    public async Task ProtectedEndpoint_NoApiKey_Returns401()
+    {
+        using var noAuthClient = CreateClientWithoutApiKey();
+        var response = await GetRawAsync("/api/audio/devices", noAuthClient);
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WrongApiKey_Returns401()
+    {
+        using var badKeyClient = CreateClientWithApiKey("totally-wrong-api-key");
+        var response = await GetRawAsync("/api/audio/devices", badKeyClient);
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_ValidApiKey_Returns200()
+    {
+        var response = await GetRawAsync("/api/audio/devices");
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK);
+    }
+}

--- a/tests/HaPcRemote.IntegrationTests/HaPcRemote.IntegrationTests.csproj
+++ b/tests/HaPcRemote.IntegrationTests/HaPcRemote.IntegrationTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.IntegrationTests.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tests/HaPcRemote.IntegrationTests/HealthEndpointTests.cs
+++ b/tests/HaPcRemote.IntegrationTests/HealthEndpointTests.cs
@@ -1,0 +1,35 @@
+using HaPcRemote.IntegrationTests.Models;
+using Shouldly;
+
+namespace HaPcRemote.IntegrationTests;
+
+[Trait("Category", "ReadOnly")]
+public class HealthEndpointTests : IntegrationTestBase
+{
+    [Fact]
+    public async Task Health_ReturnsOk_WithMachineInfo()
+    {
+        var response = await GetAsync<HealthResponse>("/api/health");
+
+        response.Success.ShouldBeTrue();
+        response.Data.ShouldNotBeNull();
+        response.Data.MachineName.ShouldNotBeNullOrWhiteSpace();
+        response.Data.MacAddresses.ShouldNotBeNull();
+        response.Data.MacAddresses.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Health_NoApiKey_StillWorks()
+    {
+        using var noAuthClient = CreateClientWithoutApiKey();
+        var response = await GetRawAsync("/api/health", noAuthClient);
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK);
+
+        var body = await DeserializeAsync<ApiResponse<HealthResponse>>(response);
+        body.ShouldNotBeNull();
+        body.Success.ShouldBeTrue();
+        body.Data.ShouldNotBeNull();
+        body.Data.MachineName.ShouldNotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/HaPcRemote.IntegrationTests/IntegrationTestBase.cs
+++ b/tests/HaPcRemote.IntegrationTests/IntegrationTestBase.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using HaPcRemote.IntegrationTests.Models;
+using Microsoft.Extensions.Configuration;
+
+namespace HaPcRemote.IntegrationTests;
+
+public abstract class IntegrationTestBase : IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    protected HttpClient Client { get; }
+    protected string BaseUrl { get; }
+    protected string ApiKey { get; }
+
+    protected IntegrationTestBase()
+    {
+        var config = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("appsettings.IntegrationTests.json", optional: false)
+            .AddEnvironmentVariables()
+            .Build();
+
+        BaseUrl = Environment.GetEnvironmentVariable("PCREMOTE_BASE_URL")
+                  ?? config["ServiceBaseUrl"]
+                  ?? throw new InvalidOperationException("ServiceBaseUrl not configured");
+
+        ApiKey = Environment.GetEnvironmentVariable("PCREMOTE_API_KEY")
+                 ?? config["ApiKey"]
+                 ?? throw new InvalidOperationException("ApiKey not configured");
+
+        Client = new HttpClient { BaseAddress = new Uri(BaseUrl) };
+        Client.DefaultRequestHeaders.Add("X-Api-Key", ApiKey);
+    }
+
+    protected HttpClient CreateClientWithoutApiKey()
+    {
+        return new HttpClient { BaseAddress = new Uri(BaseUrl) };
+    }
+
+    protected HttpClient CreateClientWithApiKey(string apiKey)
+    {
+        var client = new HttpClient { BaseAddress = new Uri(BaseUrl) };
+        client.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+        return client;
+    }
+
+    protected async Task<ApiResponse<T>> GetAsync<T>(string path)
+    {
+        var response = await Client.GetAsync(path);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<ApiResponse<T>>(JsonOptions);
+        return result ?? throw new InvalidOperationException($"Failed to deserialize response from {path}");
+    }
+
+    protected async Task<ApiResponse> PostAsync(string path)
+    {
+        var response = await Client.PostAsync(path, null);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<ApiResponse>(JsonOptions);
+        return result ?? throw new InvalidOperationException($"Failed to deserialize response from {path}");
+    }
+
+    protected async Task<HttpResponseMessage> GetRawAsync(string path, HttpClient? client = null)
+    {
+        return await (client ?? Client).GetAsync(path);
+    }
+
+    protected async Task<HttpResponseMessage> PostRawAsync(string path, HttpClient? client = null)
+    {
+        return await (client ?? Client).PostAsync(path, null);
+    }
+
+    protected static async Task<T?> DeserializeAsync<T>(HttpResponseMessage response)
+    {
+        return await response.Content.ReadFromJsonAsync<T>(JsonOptions);
+    }
+
+    public void Dispose()
+    {
+        Client.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/HaPcRemote.IntegrationTests/Models/ApiResponse.cs
+++ b/tests/HaPcRemote.IntegrationTests/Models/ApiResponse.cs
@@ -1,0 +1,14 @@
+namespace HaPcRemote.IntegrationTests.Models;
+
+public class ApiResponse
+{
+    public bool Success { get; set; }
+    public string? Message { get; set; }
+}
+
+public class ApiResponse<T>
+{
+    public bool Success { get; set; }
+    public string? Message { get; set; }
+    public T? Data { get; set; }
+}

--- a/tests/HaPcRemote.IntegrationTests/Models/AppInfo.cs
+++ b/tests/HaPcRemote.IntegrationTests/Models/AppInfo.cs
@@ -1,0 +1,8 @@
+namespace HaPcRemote.IntegrationTests.Models;
+
+public class AppInfo
+{
+    public string Key { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public bool IsRunning { get; set; }
+}

--- a/tests/HaPcRemote.IntegrationTests/Models/AudioDevice.cs
+++ b/tests/HaPcRemote.IntegrationTests/Models/AudioDevice.cs
@@ -1,0 +1,8 @@
+namespace HaPcRemote.IntegrationTests.Models;
+
+public class AudioDevice
+{
+    public string Name { get; set; } = string.Empty;
+    public int Volume { get; set; }
+    public bool IsDefault { get; set; }
+}

--- a/tests/HaPcRemote.IntegrationTests/Models/HealthResponse.cs
+++ b/tests/HaPcRemote.IntegrationTests/Models/HealthResponse.cs
@@ -1,0 +1,15 @@
+namespace HaPcRemote.IntegrationTests.Models;
+
+public class HealthResponse
+{
+    public string Status { get; set; } = string.Empty;
+    public string? MachineName { get; set; }
+    public List<MacAddressInfo>? MacAddresses { get; set; }
+}
+
+public class MacAddressInfo
+{
+    public string InterfaceName { get; set; } = string.Empty;
+    public string MacAddress { get; set; } = string.Empty;
+    public string IpAddress { get; set; } = string.Empty;
+}

--- a/tests/HaPcRemote.IntegrationTests/Models/MonitorInfo.cs
+++ b/tests/HaPcRemote.IntegrationTests/Models/MonitorInfo.cs
@@ -1,0 +1,14 @@
+namespace HaPcRemote.IntegrationTests.Models;
+
+public class MonitorInfo
+{
+    public string Name { get; set; } = string.Empty;
+    public string MonitorId { get; set; } = string.Empty;
+    public string? SerialNumber { get; set; }
+    public string MonitorName { get; set; } = string.Empty;
+    public int Width { get; set; }
+    public int Height { get; set; }
+    public int DisplayFrequency { get; set; }
+    public bool IsActive { get; set; }
+    public bool IsPrimary { get; set; }
+}

--- a/tests/HaPcRemote.IntegrationTests/Models/MonitorProfile.cs
+++ b/tests/HaPcRemote.IntegrationTests/Models/MonitorProfile.cs
@@ -1,0 +1,6 @@
+namespace HaPcRemote.IntegrationTests.Models;
+
+public class MonitorProfile
+{
+    public string Name { get; set; } = string.Empty;
+}

--- a/tests/HaPcRemote.IntegrationTests/MonitorEndpointTests.cs
+++ b/tests/HaPcRemote.IntegrationTests/MonitorEndpointTests.cs
@@ -1,0 +1,101 @@
+using HaPcRemote.IntegrationTests.Models;
+using Shouldly;
+
+namespace HaPcRemote.IntegrationTests;
+
+public class MonitorEndpointTests : IntegrationTestBase
+{
+    [Fact]
+    [Trait("Category", "ReadOnly")]
+    public async Task GetMonitors_ReturnsList()
+    {
+        var response = await GetAsync<List<MonitorInfo>>("/api/monitor/list");
+
+        response.Success.ShouldBeTrue();
+        response.Data.ShouldNotBeNull();
+        response.Data.ShouldNotBeEmpty();
+
+        var first = response.Data.First();
+        first.Name.ShouldNotBeNullOrWhiteSpace();
+        first.MonitorId.ShouldNotBeNullOrWhiteSpace();
+        first.Width.ShouldBeGreaterThan(0);
+        first.Height.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    [Trait("Category", "ReadOnly")]
+    public async Task GetMonitors_HasActiveMonitor()
+    {
+        var response = await GetAsync<List<MonitorInfo>>("/api/monitor/list");
+
+        response.Data.ShouldNotBeNull();
+        response.Data.ShouldContain(m => m.IsActive);
+    }
+
+    [Fact]
+    [Trait("Category", "ReadOnly")]
+    public async Task GetMonitors_HasPrimaryMonitor()
+    {
+        var response = await GetAsync<List<MonitorInfo>>("/api/monitor/list");
+
+        response.Data.ShouldNotBeNull();
+        response.Data.Count(m => m.IsPrimary).ShouldBe(1);
+    }
+
+    [Fact]
+    [Trait("Category", "ReadOnly")]
+    public async Task GetProfiles_ReturnsList()
+    {
+        var response = await GetAsync<List<MonitorProfile>>("/api/monitor/profiles");
+
+        response.Success.ShouldBeTrue();
+        // List may be empty if no profiles are configured — that's fine
+        response.Data.ShouldNotBeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Mutating")]
+    public async Task EnableMonitor_ValidId_ReturnsOk()
+    {
+        var monitors = await GetAsync<List<MonitorInfo>>("/api/monitor/list");
+        monitors.Data.ShouldNotBeNull();
+
+        var active = monitors.Data.First(m => m.IsActive);
+        var encodedId = Uri.EscapeDataString(active.MonitorId);
+
+        var response = await PostAsync($"/api/monitor/enable/{encodedId}");
+        response.Success.ShouldBeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Mutating")]
+    public async Task EnableMonitor_InvalidId_Returns404()
+    {
+        var response = await PostRawAsync("/api/monitor/enable/nonexistent123");
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    [Trait("Category", "Mutating")]
+    public async Task SetPrimary_ValidId_ReturnsOk()
+    {
+        var monitors = await GetAsync<List<MonitorInfo>>("/api/monitor/list");
+        monitors.Data.ShouldNotBeNull();
+
+        var primary = monitors.Data.First(m => m.IsPrimary);
+        var encodedId = Uri.EscapeDataString(primary.MonitorId);
+
+        var response = await PostAsync($"/api/monitor/primary/{encodedId}");
+        response.Success.ShouldBeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Mutating")]
+    public async Task SetPrimary_InvalidId_Returns404()
+    {
+        var response = await PostRawAsync("/api/monitor/primary/nonexistent123");
+
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.NotFound);
+    }
+}

--- a/tests/HaPcRemote.IntegrationTests/SystemEndpointTests.cs
+++ b/tests/HaPcRemote.IntegrationTests/SystemEndpointTests.cs
@@ -1,0 +1,14 @@
+namespace HaPcRemote.IntegrationTests;
+
+public class SystemEndpointTests : IntegrationTestBase
+{
+    [Fact(Skip = "Would put machine to sleep")]
+    [Trait("Category", "Mutating")]
+    public async Task Sleep_Endpoint_Exists()
+    {
+        // DO NOT call this — it would put the machine to sleep.
+        // This test exists only as documentation that the endpoint is present.
+        var response = await PostRawAsync("/api/system/sleep");
+        Assert.NotEqual(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/tests/HaPcRemote.Service.Tests/Endpoints/MonitorEndpointTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Endpoints/MonitorEndpointTests.cs
@@ -12,11 +12,22 @@ public class MonitorEndpointTests : EndpointTestBase
         @"\\.\DISPLAY1,GSM59A4,GSM59A4-1234,Active,\\.\DISPLAY1\GSM59A4,LG ULTRAGEAR,ABC123,NVIDIA,3840x2160,0,3840,2160,32,144,Yes" + "\n"
       + @"\\.\DISPLAY2,DEL4321,DEL4321-5678,Active,\\.\DISPLAY2\DEL4321,Dell U2723QE,XYZ789,NVIDIA,2560x1440,0,2560,1440,32,60,No";
 
+    private void SetupCliRunnerWithCsv()
+    {
+        A.CallTo(() => CliRunner.RunAsync(A<string>._, A<IEnumerable<string>>._, A<int>._))
+            .Invokes((string _, IEnumerable<string> args, int _) =>
+            {
+                var argList = args.ToList();
+                if (argList.Count >= 2 && argList[0] == "/scomma" && !string.IsNullOrEmpty(argList[1]))
+                    File.WriteAllText(argList[1], SampleCsv);
+            })
+            .Returns(string.Empty);
+    }
+
     [Fact]
     public async Task GetMonitors_ReturnsMonitorList()
     {
-        A.CallTo(() => CliRunner.RunAsync(A<string>._, A<IEnumerable<string>>._, A<int>._))
-            .Returns(SampleCsv);
+        SetupCliRunnerWithCsv();
         using var client = CreateClient();
 
         var response = await client.GetAsync("/api/monitor/list");
@@ -31,8 +42,7 @@ public class MonitorEndpointTests : EndpointTestBase
     [Fact]
     public async Task EnableMonitor_UnknownId_Returns404()
     {
-        A.CallTo(() => CliRunner.RunAsync(A<string>._, A<IEnumerable<string>>._, A<int>._))
-            .Returns(SampleCsv);
+        SetupCliRunnerWithCsv();
         using var client = CreateClient();
 
         var response = await client.PostAsync("/api/monitor/enable/UNKNOWN", null);
@@ -43,8 +53,7 @@ public class MonitorEndpointTests : EndpointTestBase
     [Fact]
     public async Task EnableMonitor_ValidId_ReturnsOk()
     {
-        A.CallTo(() => CliRunner.RunAsync(A<string>._, A<IEnumerable<string>>._, A<int>._))
-            .Returns(SampleCsv);
+        SetupCliRunnerWithCsv();
         using var client = CreateClient();
 
         var response = await client.PostAsync("/api/monitor/enable/DEL4321", null);


### PR DESCRIPTION
## Summary
- Fix MultiMonitorTool opening its GUI window on every HA poll cycle. Root cause: `/scomma ""` (empty string) triggers GUI mode instead of stdout output. Fix: write to temp file, read, delete.
- Add black-box integration test project (28 tests) for live endpoint validation.

## Test plan
- [x] 120/120 unit tests pass
- [ ] Run integration tests from Windows: `dotnet test tests\HaPcRemote.IntegrationTests\ --filter "Category=ReadOnly"`
- [ ] Verify no MultiMonitorTool window flashes on HA polling