### PR TITLE
fix: audio filtering, monitor solo order, and CI trimming error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
           -r win-x64
           --self-contained
           /p:PublishSingleFile=true
-          /p:PublishTrimmed=true
           /p:Version=${{ steps.version.outputs.version }}
           -o publish/tray
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ Requires `SoundVolumeView.exe` in `ToolsPath`.
 | `POST` | `/api/audio/set/{deviceName}` | Switch default output device |
 | `POST` | `/api/audio/volume/{level}` | Set master volume (0-100) |
 
-> **TODO:** Filter `GET /api/audio/devices` to return only hardware sound card output devices. Currently, virtual audio devices created by applications (e.g. communication apps) appear in the list alongside real output devices.
-
 ### Monitors — Direct Control
 
 Requires `MultiMonitorTool.exe` in `ToolsPath`.
@@ -89,12 +87,10 @@ Requires `MultiMonitorTool.exe` in `ToolsPath`.
 | Method | Route | Description |
 |--------|-------|-------------|
 | `GET` | `/api/monitor/list` | List connected monitors |
-| `POST` | `/api/monitor/solo/{id}` | Enable only this monitor, disable all others |
+| `POST` | `/api/monitor/solo/{id}` | Enable this monitor, set as primary, disable all others |
 | `POST` | `/api/monitor/enable/{id}` | Enable a monitor |
 | `POST` | `/api/monitor/disable/{id}` | Disable a monitor |
 | `POST` | `/api/monitor/primary/{id}` | Set a monitor as primary |
-
-> **TODO:** Monitor switching is unreliable across repeated toggling. Known symptoms: (1) first switch — both monitors stay on; (2) switching back — correctly disables monitor 2; (3) re-enabling monitor 2 as primary — does nothing. Root cause likely a race or state issue in MultiMonitorTool when called in rapid succession, or incorrect sequencing of enable/primary/disable operations. Also, `solo/{id}` should set the selected monitor as primary; selecting a monitor should mean: enable + set as primary + disable all others.
 
 ### Monitors — Profiles
 
@@ -187,6 +183,8 @@ dotnet build HaPcRemote.sln
 dotnet test HaPcRemote.sln
 dotnet publish src/HaPcRemote.Service -c Release -r win-x64 /p:PublishAot=true
 ```
+
+> **TODO:** Tray app installer is ~46 MB because `--self-contained` bundles the full .NET runtime. WinForms does not support trimming (`NETSDK1175`), so size cannot be reduced that way. Options: (1) framework-dependent publish + Inno Setup prerequisite to install .NET if missing; (2) accept current size.
 
 ## License
 

--- a/tests/HaPcRemote.Service.Tests/Endpoints/AudioEndpointTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Endpoints/AudioEndpointTests.cs
@@ -8,7 +8,7 @@ namespace HaPcRemote.Service.Tests.Endpoints;
 
 public class AudioEndpointTests : EndpointTestBase
 {
-    private const string SampleCsv = "Speakers,Render,Render,50.0%\nHeadphones,Render,,75.0%";
+    private const string SampleCsv = "Device,Speakers,Render,Render,50.0%\nDevice,Headphones,Render,,75.0%";
 
     [Fact]
     public async Task GetDevices_ReturnsDeviceList()
@@ -47,7 +47,7 @@ public class AudioEndpointTests : EndpointTestBase
     public async Task GetCurrent_NoDefault_Returns404()
     {
         A.CallTo(() => CliRunner.RunAsync(A<string>._, A<IEnumerable<string>>._, A<int>._))
-            .Returns("Speakers,Render,,50.0%"); // No default
+            .Returns("Device,Speakers,Render,,50.0%"); // No default
         using var client = CreateClient();
 
         var response = await client.GetAsync("/api/audio/current");


### PR DESCRIPTION
## Summary

- **Audio**: Filter virtual/software audio devices from `GET /api/audio/devices`. Added `Type` column to SoundVolumeView query and exclude `Application`/`Subunit` rows — only `Device` (hardware) entries pass through.
- **Monitor**: Fix `solo/{id}` operation order — now enable → set primary → disable others, with 500ms delays between CLI calls to prevent race conditions. Cache invalidation added to `Enable`/`Disable`/`SetPrimary` so subsequent reads reflect actual state.
- **CI**: Remove `PublishTrimmed=true` from tray publish step. WinForms does not support trimming (`NETSDK1175`). Installer size remains ~46 MB.

## Test plan

- [ ] 154 unit tests pass
- [ ] CI build passes (trimming error gone)
- [ ] Audio device list excludes virtual/communication devices
- [ ] Monitor solo correctly sets primary + disables others