### PR TITLE
feat: auto-update toggle in tray

### DIFF
--- a/src/HaPcRemote.Shared/Configuration/ConfigPaths.cs
+++ b/src/HaPcRemote.Shared/Configuration/ConfigPaths.cs
@@ -33,6 +33,9 @@ public static class ConfigPaths
     public static string GetWritableConfigPath()
         => Path.Combine(GetWritableConfigDir(), "appsettings.json");
 
+    public static string GetTraySettingsPath()
+        => Path.Combine(GetWritableConfigDir(), "tray-settings.json");
+
     public static string GetLogFilePath()
         => Path.Combine(GetWritableConfigDir(), "service.log");
 

--- a/src/HaPcRemote.Tray/Models/TraySettings.cs
+++ b/src/HaPcRemote.Tray/Models/TraySettings.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using HaPcRemote.Shared.Configuration;
+
+namespace HaPcRemote.Tray.Models;
+
+internal sealed class TraySettings
+{
+    public bool AutoUpdate { get; set; } = false;
+
+    public static TraySettings Load()
+    {
+        try
+        {
+            var path = ConfigPaths.GetTraySettingsPath();
+            if (!File.Exists(path)) return new TraySettings();
+            var json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize(json, TraySettingsJsonContext.Default.TraySettings)
+                   ?? new TraySettings();
+        }
+        catch { return new TraySettings(); }
+    }
+
+    public void Save()
+    {
+        try
+        {
+            var path = ConfigPaths.GetTraySettingsPath();
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, JsonSerializer.Serialize(this, TraySettingsJsonContext.Default.TraySettings));
+        }
+        catch { }
+    }
+}
+
+[JsonSerializable(typeof(TraySettings))]
+internal sealed partial class TraySettingsJsonContext : JsonSerializerContext { }


### PR DESCRIPTION
## Summary
- Adds **Auto Update** checkbox to tray context menu (off by default)
- When enabled: polls for updates every 5 minutes; auto-installs 5 seconds after detecting a new release (balloon shown first)
- When disabled: existing 4-hour poll interval, manual click required
- Setting persists to `%ProgramData%\HaPcRemote\tray-settings.json`

## Changes
- `ConfigPaths.cs` — `GetTraySettingsPath()` helper
- `TraySettings.cs` — new model with `Load()`/`Save()`, source-gen JSON context
- `TrayApplicationContext.cs` — toggle field, settings load on startup, dynamic timer interval, auto-install trigger

## Test plan
- [ ] Tray menu shows "Auto Update" checkbox, unchecked by default
- [ ] Toggling on writes `tray-settings.json` with `"AutoUpdate":true`; toggle survives restart
- [ ] With auto-update on: update check fires every 5 minutes
- [ ] With auto-update on: when update detected, installs automatically after 5s balloon
- [ ] With auto-update off: 4-hour interval, no auto-install
- [ ] UAC cancel on auto-install re-enables menu item gracefully