### PR TITLE
refactor: primary constructors + extract test data files

### DIFF
--- a/src/HaPcRemote.Service/Services/AppService.cs
+++ b/src/HaPcRemote.Service/Services/AppService.cs
@@ -5,20 +5,11 @@ using Microsoft.Extensions.Options;
 
 namespace HaPcRemote.Service.Services;
 
-public class AppService
+public class AppService(IOptionsMonitor<PcRemoteOptions> options, IAppLauncher appLauncher)
 {
-    private readonly IOptionsMonitor<PcRemoteOptions> _options;
-    private readonly IAppLauncher _appLauncher;
-
-    public AppService(IOptionsMonitor<PcRemoteOptions> options, IAppLauncher appLauncher)
-    {
-        _options = options;
-        _appLauncher = appLauncher;
-    }
-
     public Task<List<AppInfo>> GetAllStatusesAsync()
     {
-        var apps = _options.CurrentValue.Apps;
+        var apps = options.CurrentValue.Apps;
         if (apps is null || apps.Count == 0)
             return Task.FromResult(new List<AppInfo>());
 
@@ -39,7 +30,7 @@ public class AppService
     public async Task LaunchAsync(string appKey)
     {
         var definition = GetDefinition(appKey);
-        await _appLauncher.LaunchAsync(definition.ExePath, definition.Arguments);
+        await appLauncher.LaunchAsync(definition.ExePath, definition.Arguments);
     }
 
     public Task KillAsync(string appKey)
@@ -72,7 +63,7 @@ public class AppService
 
     private AppDefinitionOptions GetDefinition(string appKey)
     {
-        var apps = _options.CurrentValue.Apps;
+        var apps = options.CurrentValue.Apps;
         if (!apps.TryGetValue(appKey, out var definition))
             throw new KeyNotFoundException($"App '{appKey}' is not configured.");
 

--- a/src/HaPcRemote.Service/Services/IpcSteamPlatform.cs
+++ b/src/HaPcRemote.Service/Services/IpcSteamPlatform.cs
@@ -6,15 +6,8 @@ namespace HaPcRemote.Service.Services;
 /// ISteamPlatform implementation that delegates all Steam operations to the tray app via IPC.
 /// The tray runs in the user session and has access to HKCU registry and user-session process launch.
 /// </summary>
-public sealed class IpcSteamPlatform : ISteamPlatform
+public sealed class IpcSteamPlatform(ILogger<IpcSteamPlatform> logger) : ISteamPlatform
 {
-    private readonly ILogger<IpcSteamPlatform> _logger;
-
-    public IpcSteamPlatform(ILogger<IpcSteamPlatform> logger)
-    {
-        _logger = logger;
-    }
-
     public string? GetSteamPath()
     {
         var response = Send(new IpcRequest { Type = "steamGetPath" });
@@ -54,7 +47,7 @@ public sealed class IpcSteamPlatform : ISteamPlatform
         var client = new IpcClient();
         var response = client.SendAsync(request, CancellationToken.None).GetAwaiter().GetResult();
         if (response is null)
-            _logger.LogWarning("Tray not connected — Steam IPC call '{Type}' skipped", request.Type);
+            logger.LogWarning("Tray not connected — Steam IPC call '{Type}' skipped", request.Type);
         return response;
     }
 }

--- a/src/HaPcRemote.Service/Services/TrayAppLauncher.cs
+++ b/src/HaPcRemote.Service/Services/TrayAppLauncher.cs
@@ -7,15 +7,8 @@ namespace HaPcRemote.Service.Services;
 /// Delegates process launches to the tray app via IPC.
 /// Falls back to direct Process.Start if the tray is not connected.
 /// </summary>
-public sealed class TrayAppLauncher : IAppLauncher
+public sealed class TrayAppLauncher(ILogger<TrayAppLauncher> logger) : IAppLauncher
 {
-    private readonly ILogger<TrayAppLauncher> _logger;
-
-    public TrayAppLauncher(ILogger<TrayAppLauncher> logger)
-    {
-        _logger = logger;
-    }
-
     public async Task LaunchAsync(string exePath, string? arguments = null)
     {
         var client = new IpcClient();
@@ -28,7 +21,7 @@ public sealed class TrayAppLauncher : IAppLauncher
 
         if (response is null)
         {
-            _logger.LogWarning("Tray not connected, launching process directly");
+            logger.LogWarning("Tray not connected, launching process directly");
             var startInfo = new ProcessStartInfo
             {
                 FileName = exePath,

--- a/src/HaPcRemote.Service/Services/TrayCliRunner.cs
+++ b/src/HaPcRemote.Service/Services/TrayCliRunner.cs
@@ -6,16 +6,9 @@ namespace HaPcRemote.Service.Services;
 /// ICliRunner that delegates execution to the tray app via named pipe IPC.
 /// Falls back to direct execution if the tray is not running (dev mode).
 /// </summary>
-public sealed class TrayCliRunner : ICliRunner
+public sealed class TrayCliRunner(ILogger<TrayCliRunner> logger) : ICliRunner
 {
-    private readonly ICliRunner _fallback;
-    private readonly ILogger<TrayCliRunner> _logger;
-
-    public TrayCliRunner(ILogger<TrayCliRunner> logger)
-    {
-        _fallback = new CliRunner();
-        _logger = logger;
-    }
+    private readonly CliRunner _fallback = new();
 
     public async Task<string> RunAsync(string exePath, IEnumerable<string> arguments, int timeoutMs = 10000)
     {
@@ -32,7 +25,7 @@ public sealed class TrayCliRunner : ICliRunner
 
         if (response is null)
         {
-            _logger.LogWarning("Tray not connected, falling back to direct execution");
+            logger.LogWarning("Tray not connected, falling back to direct execution");
             return await _fallback.RunAsync(exePath, args, timeoutMs);
         }
 

--- a/src/HaPcRemote.Shared/Ipc/IpcRequestHandler.cs
+++ b/src/HaPcRemote.Shared/Ipc/IpcRequestHandler.cs
@@ -8,18 +8,12 @@ namespace HaPcRemote.Shared.Ipc;
 /// Handles IPC requests by dispatching to the appropriate handler method.
 /// Extracted from TrayApplicationContext so process execution logic is testable.
 /// </summary>
-public sealed class IpcRequestHandler
+public sealed class IpcRequestHandler(ILogger logger)
 {
-    private readonly ILogger _logger;
-
-    public IpcRequestHandler(ILogger logger)
-    {
-        _logger = logger;
-    }
 
     public async Task<IpcResponse> HandleAsync(IpcRequest request, CancellationToken ct)
     {
-        _logger.LogDebug("IPC ← {Type}", request.Type);
+        logger.LogDebug("IPC ← {Type}", request.Type);
 
         var response = request.Type switch
         {
@@ -39,10 +33,10 @@ public sealed class IpcRequestHandler
             var preview = response.Stdout is { Length: > 120 }
                 ? response.Stdout[..120] + "…"
                 : response.Stdout;
-            _logger.LogDebug("IPC → {Type} ok stdout={Stdout}", request.Type, preview);
+            logger.LogDebug("IPC → {Type} ok stdout={Stdout}", request.Type, preview);
         }
         else
-            _logger.LogDebug("IPC → {Type} FAIL {Error}", request.Type, response.Error);
+            logger.LogDebug("IPC → {Type} FAIL {Error}", request.Type, response.Error);
 
         return response;
     }

--- a/tests/HaPcRemote.Service.Tests/Endpoints/AudioEndpointTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Endpoints/AudioEndpointTests.cs
@@ -81,7 +81,7 @@ public class AudioEndpointTests : EndpointTestBase
             AppJsonContext.Default.ApiResponse);
         json.ShouldNotBeNull();
         json.Success.ShouldBeFalse();
-        json.Message.ShouldContain("between 0 and 100");
+        json.Message!.ShouldContain("between 0 and 100");
     }
 
     [Fact]
@@ -110,6 +110,6 @@ public class AudioEndpointTests : EndpointTestBase
             AppJsonContext.Default.ApiResponse);
         json.ShouldNotBeNull();
         json.Success.ShouldBeFalse();
-        json.Message.ShouldContain("not found");
+        json.Message!.ShouldContain("not found");
     }
 }

--- a/tests/HaPcRemote.Service.Tests/HaPcRemote.Service.Tests.csproj
+++ b/tests/HaPcRemote.Service.Tests/HaPcRemote.Service.Tests.csproj
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="TestData\**" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\HaPcRemote.Service\HaPcRemote.Service.csproj" />
     <ProjectReference Include="..\..\src\HaPcRemote.Shared\HaPcRemote.Shared.csproj" />
   </ItemGroup>

--- a/tests/HaPcRemote.Service.Tests/Ipc/IpcRequestHandlerTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Ipc/IpcRequestHandlerTests.cs
@@ -28,7 +28,7 @@ public class IpcRequestHandlerTests
         var request = new IpcRequest { Type = "unknown_type" };
         var response = await _handler.HandleAsync(request, CancellationToken.None);
         response.Success.ShouldBeFalse();
-        response.Error.ShouldContain("Unknown request type");
+        response.Error!.ShouldContain("Unknown request type");
     }
 
     [Fact]
@@ -37,7 +37,7 @@ public class IpcRequestHandlerTests
         var request = new IpcRequest { Type = "runCli" };
         var response = await _handler.HandleAsync(request, CancellationToken.None);
         response.Success.ShouldBeFalse();
-        response.Error.ShouldContain("ExePath is required");
+        response.Error!.ShouldContain("ExePath is required");
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public class IpcRequestHandlerTests
         var request = new IpcRequest { Type = "runCli", ExePath = "/nonexistent/tool.exe" };
         var response = await _handler.HandleAsync(request, CancellationToken.None);
         response.Success.ShouldBeFalse();
-        response.Error.ShouldContain("not found");
+        response.Error!.ShouldContain("not found");
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class IpcRequestHandlerTests
         var request = new IpcRequest { Type = "launchProcess" };
         var response = await _handler.HandleAsync(request, CancellationToken.None);
         response.Success.ShouldBeFalse();
-        response.Error.ShouldContain("ExePath is required");
+        response.Error!.ShouldContain("ExePath is required");
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class IpcRequestHandlerTests
             // Registry may not have Steam installed in CI — Success with null Stdout is valid
             response.Success.ShouldBeTrue();
         else
-            response.Error.ShouldContain("Windows");
+            response.Error!.ShouldContain("Windows");
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class IpcRequestHandlerTests
         }
         else
         {
-            response.Error.ShouldContain("Windows");
+            response.Error!.ShouldContain("Windows");
         }
     }
 
@@ -92,7 +92,7 @@ public class IpcRequestHandlerTests
         var request = new IpcRequest { Type = "steamLaunchUrl" };
         var response = await _handler.HandleAsync(request, CancellationToken.None);
         response.Success.ShouldBeFalse();
-        response.Error.ShouldContain("ProcessArguments");
+        response.Error!.ShouldContain("ProcessArguments");
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class IpcRequestHandlerTests
         var request = new IpcRequest { Type = "steamKillDir" };
         var response = await _handler.HandleAsync(request, CancellationToken.None);
         response.Success.ShouldBeFalse();
-        response.Error.ShouldContain("ProcessArguments");
+        response.Error!.ShouldContain("ProcessArguments");
     }
 
     [Fact]

--- a/tests/HaPcRemote.Service.Tests/Services/MonitorServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/MonitorServiceTests.cs
@@ -13,7 +13,7 @@ public class MonitorServiceTests : IDisposable
     private readonly string _tempDir;
     private readonly ICliRunner _cliRunner = A.Fake<ICliRunner>();
 
-    private void SetupCliRunnerWithXml(string xml = SampleXml)
+    private void SetupCliRunnerWithXml(string xml)
     {
         A.CallTo(() => _cliRunner.RunAsync(A<string>._, A<IEnumerable<string>>._, A<int>._))
             .Invokes((string _, IEnumerable<string> args, int _) =>
@@ -24,115 +24,6 @@ public class MonitorServiceTests : IDisposable
             })
             .Returns(string.Empty);
     }
-
-    // Realistic MultiMonitorTool /sxml output based on actual tool output
-    private const string SampleXml =
-        """
-        <?xml version="1.0" ?>
-        <monitors_list>
-        <item>
-        <resolution>3840 X 2160</resolution>
-        <left-top>0, 0</left-top>
-        <right-bottom>3840, 2160</right-bottom>
-        <active>Yes</active>
-        <disconnected>No</disconnected>
-        <primary>Yes</primary>
-        <colors>32</colors>
-        <frequency>144</frequency>
-        <orientation>Default</orientation>
-        <maximum_resolution>3840 X 2160</maximum_resolution>
-        <current_scale>100%</current_scale>
-        <maximum_scale>200%</maximum_scale>
-        <name>\\.\DISPLAY1</name>
-        <adapter>NVIDIA GeForce</adapter>
-        <device_id>PCI\VEN_10DE</device_id>
-        <device_key>\Registry\Machine\System\CurrentControlSet\Control\Video\{ABC}\0000</device_key>
-        <monitor_id>MONITOR\GSM59A4\{4d36e96e-e325-11ce-bfc1-08002be10318}\0001</monitor_id>
-        <short_monitor_id>GSM59A4</short_monitor_id>
-        <monitor_key>\Registry\Machine\System\CurrentControlSet\Control\Class\{4d36e96e}\0001</monitor_key>
-        <monitor_string>LG ULTRAGEAR</monitor_string>
-        <monitor_name>LG ULTRAGEAR</monitor_name>
-        <monitor_serial_number>ABC123</monitor_serial_number>
-        </item>
-        <item>
-        <resolution>2560 X 1440</resolution>
-        <left-top>3840, 0</left-top>
-        <right-bottom>6400, 1440</right-bottom>
-        <active>Yes</active>
-        <disconnected>No</disconnected>
-        <primary>No</primary>
-        <colors>32</colors>
-        <frequency>60</frequency>
-        <orientation>Default</orientation>
-        <maximum_resolution>2560 X 1440</maximum_resolution>
-        <current_scale>100%</current_scale>
-        <maximum_scale>200%</maximum_scale>
-        <name>\\.\DISPLAY2</name>
-        <adapter>NVIDIA GeForce</adapter>
-        <device_id>PCI\VEN_10DE</device_id>
-        <device_key>\Registry\Machine\System\CurrentControlSet\Control\Video\{DEF}\0001</device_key>
-        <monitor_id>MONITOR\DEL4321\{4d36e96e-e325-11ce-bfc1-08002be10318}\0002</monitor_id>
-        <short_monitor_id>DEL4321</short_monitor_id>
-        <monitor_key>\Registry\Machine\System\CurrentControlSet\Control\Class\{4d36e96e}\0002</monitor_key>
-        <monitor_string>Dell U2723QE</monitor_string>
-        <monitor_name>Dell U2723QE</monitor_name>
-        <monitor_serial_number>XYZ789</monitor_serial_number>
-        </item>
-        <item>
-        <resolution>1920 X 1080</resolution>
-        <left-top>6400, 0</left-top>
-        <right-bottom>8320, 1080</right-bottom>
-        <active>Yes</active>
-        <disconnected>No</disconnected>
-        <primary>No</primary>
-        <colors>32</colors>
-        <frequency>240</frequency>
-        <orientation>Default</orientation>
-        <maximum_resolution>1920 X 1080</maximum_resolution>
-        <current_scale>100%</current_scale>
-        <maximum_scale>200%</maximum_scale>
-        <name>\\.\DISPLAY3</name>
-        <adapter>NVIDIA GeForce</adapter>
-        <device_id>PCI\VEN_10DE</device_id>
-        <device_key>\Registry\Machine\System\CurrentControlSet\Control\Video\{GHI}\0002</device_key>
-        <monitor_id>MONITOR\SAM0F00\{4d36e96e-e325-11ce-bfc1-08002be10318}\0003</monitor_id>
-        <short_monitor_id>SAM0F00</short_monitor_id>
-        <monitor_key>\Registry\Machine\System\CurrentControlSet\Control\Class\{4d36e96e}\0003</monitor_key>
-        <monitor_string>Samsung Odyssey</monitor_string>
-        <monitor_name>Samsung Odyssey</monitor_name>
-        <monitor_serial_number></monitor_serial_number>
-        </item>
-        </monitors_list>
-        """;
-
-    private const string XmlWithDisconnected =
-        """
-        <?xml version="1.0" ?>
-        <monitors_list>
-        <item>
-        <resolution>3840 X 2160</resolution>
-        <active>Yes</active>
-        <disconnected>No</disconnected>
-        <primary>Yes</primary>
-        <frequency>144</frequency>
-        <name>\\.\DISPLAY1</name>
-        <short_monitor_id>GSM59A4</short_monitor_id>
-        <monitor_name>LG ULTRAGEAR</monitor_name>
-        <monitor_serial_number>ABC123</monitor_serial_number>
-        </item>
-        <item>
-        <resolution></resolution>
-        <active>No</active>
-        <disconnected>Yes</disconnected>
-        <primary>No</primary>
-        <frequency>0</frequency>
-        <name>\\.\DISPLAY4</name>
-        <short_monitor_id>AOC1234</short_monitor_id>
-        <monitor_name>AOC Monitor</monitor_name>
-        <monitor_serial_number>DISC01</monitor_serial_number>
-        </item>
-        </monitors_list>
-        """;
 
     public MonitorServiceTests()
     {
@@ -240,7 +131,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void ParseXmlOutput_ParsesAllConnectedMonitors()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         monitors.Count.ShouldBe(3);
     }
@@ -248,7 +139,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void ParseXmlOutput_ParsesDisplayName()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         monitors[0].Name.ShouldBe(@"\\.\DISPLAY1");
         monitors[1].Name.ShouldBe(@"\\.\DISPLAY2");
@@ -257,7 +148,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void ParseXmlOutput_ParsesShortMonitorId()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         monitors[0].MonitorId.ShouldBe("GSM59A4");
         monitors[1].MonitorId.ShouldBe("DEL4321");
@@ -266,7 +157,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void ParseXmlOutput_ParsesFriendlyName()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         monitors[0].MonitorName.ShouldBe("LG ULTRAGEAR");
         monitors[1].MonitorName.ShouldBe("Dell U2723QE");
@@ -275,7 +166,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void ParseXmlOutput_ParsesSerialNumber()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         monitors[0].SerialNumber.ShouldBe("ABC123");
         monitors[1].SerialNumber.ShouldBe("XYZ789");
@@ -284,7 +175,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void ParseXmlOutput_EmptySerialNumber_ReturnsNull()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         monitors[2].SerialNumber.ShouldBeNull();
     }
@@ -292,7 +183,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void ParseXmlOutput_ParsesResolution()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         monitors[0].Width.ShouldBe(3840);
         monitors[0].Height.ShouldBe(2160);
@@ -303,7 +194,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void ParseXmlOutput_ParsesDisplayFrequency()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         monitors[0].DisplayFrequency.ShouldBe(144);
         monitors[1].DisplayFrequency.ShouldBe(60);
@@ -313,7 +204,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void ParseXmlOutput_IdentifiesPrimaryMonitor()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         monitors[0].IsPrimary.ShouldBeTrue();
         monitors[1].IsPrimary.ShouldBeFalse();
@@ -323,7 +214,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void ParseXmlOutput_ActiveMonitors_AreActive()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         monitors.ShouldAllBe(m => m.IsActive);
     }
@@ -331,7 +222,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void ParseXmlOutput_FiltersDisconnectedMonitors()
     {
-        var monitors = MonitorService.ParseXmlOutput(XmlWithDisconnected);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-disconnected.xml"));
 
         monitors.Count.ShouldBe(1);
         monitors[0].Name.ShouldBe(@"\\.\DISPLAY1");
@@ -449,7 +340,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void FindMonitor_MatchByDisplayName_ReturnsMonitor()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         var result = MonitorService.FindMonitor(monitors, @"\\.\DISPLAY2");
 
@@ -459,7 +350,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void FindMonitor_MatchByShortMonitorId_ReturnsMonitor()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         var result = MonitorService.FindMonitor(monitors, "DEL4321");
 
@@ -469,7 +360,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void FindMonitor_MatchBySerialNumber_ReturnsMonitor()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         var result = MonitorService.FindMonitor(monitors, "XYZ789");
 
@@ -479,7 +370,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void FindMonitor_CaseInsensitive_ReturnsMonitor()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         var result = MonitorService.FindMonitor(monitors, "gsm59a4");
 
@@ -489,7 +380,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void FindMonitor_UnknownId_ThrowsKeyNotFoundException()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         Should.Throw<KeyNotFoundException>(
             () => MonitorService.FindMonitor(monitors, "UNKNOWN123"));
@@ -507,7 +398,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public void FindMonitor_NullSerialNotMatchedByEmptyString()
     {
-        var monitors = MonitorService.ParseXmlOutput(SampleXml);
+        var monitors = MonitorService.ParseXmlOutput(TestData.Load("monitors-sample.xml"));
 
         Should.Throw<KeyNotFoundException>(
             () => MonitorService.FindMonitor(monitors, ""));
@@ -518,7 +409,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public async Task GetMonitorsAsync_CallsCliRunnerAndParsesOutput()
     {
-        SetupCliRunnerWithXml();
+        SetupCliRunnerWithXml(TestData.Load("monitors-sample.xml"));
         var service = CreateService();
 
         var monitors = await service.GetMonitorsAsync();
@@ -534,7 +425,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public async Task EnableMonitorAsync_ResolvesAndCallsCliRunner()
     {
-        SetupCliRunnerWithXml();
+        SetupCliRunnerWithXml(TestData.Load("monitors-sample.xml"));
         var service = CreateService();
 
         await service.EnableMonitorAsync("DEL4321");
@@ -548,7 +439,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public async Task DisableMonitorAsync_ResolvesAndCallsCliRunner()
     {
-        SetupCliRunnerWithXml();
+        SetupCliRunnerWithXml(TestData.Load("monitors-sample.xml"));
         var service = CreateService();
 
         await service.DisableMonitorAsync("GSM59A4");
@@ -562,7 +453,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public async Task SetPrimaryAsync_ResolvesAndCallsCliRunner()
     {
-        SetupCliRunnerWithXml();
+        SetupCliRunnerWithXml(TestData.Load("monitors-sample.xml"));
         var service = CreateService();
 
         await service.SetPrimaryAsync("XYZ789");
@@ -576,7 +467,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public async Task EnableMonitorAsync_UnknownId_ThrowsKeyNotFoundException()
     {
-        SetupCliRunnerWithXml();
+        SetupCliRunnerWithXml(TestData.Load("monitors-sample.xml"));
         var service = CreateService();
 
         await Should.ThrowAsync<KeyNotFoundException>(
@@ -586,14 +477,14 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public async Task SoloMonitorAsync_TargetAlreadyActive_SetsPrimaryThenDisablesOthers()
     {
-        // DEL4321 (DISPLAY2) is already active in SampleXml
+        // DEL4321 (DISPLAY2) is already active in monitors-sample.xml
         var calls = new List<string[]>();
         A.CallTo(() => _cliRunner.RunAsync(A<string>._, A<IEnumerable<string>>._, A<int>._))
             .Invokes((string _, IEnumerable<string> args, int _) =>
             {
                 var argList = args.ToList();
                 if (argList.Count >= 2 && argList[0] == "/sxml" && !string.IsNullOrEmpty(argList[1]))
-                    File.WriteAllText(argList[1], SampleXml);
+                    File.WriteAllText(argList[1], TestData.Load("monitors-sample.xml"));
                 else
                     calls.Add(argList.ToArray());
             })
@@ -621,43 +512,13 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public async Task SoloMonitorAsync_TargetInactive_EnablesThenSetsPrimaryThenDisablesOthers()
     {
-        // Use XML where DISPLAY2 is inactive so the enable step fires
-        const string xmlWithInactiveTarget =
-            """
-            <?xml version="1.0" ?>
-            <monitors_list>
-            <item>
-            <resolution>3840 X 2160</resolution>
-            <active>Yes</active>
-            <disconnected>No</disconnected>
-            <primary>Yes</primary>
-            <frequency>144</frequency>
-            <name>\\.\DISPLAY1</name>
-            <short_monitor_id>GSM59A4</short_monitor_id>
-            <monitor_name>LG ULTRAGEAR</monitor_name>
-            <monitor_serial_number>ABC123</monitor_serial_number>
-            </item>
-            <item>
-            <resolution>2560 X 1440</resolution>
-            <active>No</active>
-            <disconnected>No</disconnected>
-            <primary>No</primary>
-            <frequency>60</frequency>
-            <name>\\.\DISPLAY2</name>
-            <short_monitor_id>DEL4321</short_monitor_id>
-            <monitor_name>Dell U2723QE</monitor_name>
-            <monitor_serial_number>XYZ789</monitor_serial_number>
-            </item>
-            </monitors_list>
-            """;
-
         var calls = new List<string[]>();
         A.CallTo(() => _cliRunner.RunAsync(A<string>._, A<IEnumerable<string>>._, A<int>._))
             .Invokes((string _, IEnumerable<string> args, int _) =>
             {
                 var argList = args.ToList();
                 if (argList.Count >= 2 && argList[0] == "/sxml" && !string.IsNullOrEmpty(argList[1]))
-                    File.WriteAllText(argList[1], xmlWithInactiveTarget);
+                    File.WriteAllText(argList[1], TestData.Load("monitors-inactive-target.xml"));
                 else
                     calls.Add(argList.ToArray());
             })
@@ -683,7 +544,7 @@ public class MonitorServiceTests : IDisposable
     [Fact]
     public async Task SoloMonitorAsync_UnknownId_ThrowsKeyNotFoundException()
     {
-        SetupCliRunnerWithXml();
+        SetupCliRunnerWithXml(TestData.Load("monitors-sample.xml"));
         var service = CreateService();
 
         await Should.ThrowAsync<KeyNotFoundException>(

--- a/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
@@ -6,40 +6,6 @@ namespace HaPcRemote.Service.Tests.Services;
 
 public class SteamServiceTests
 {
-    private const string SampleLibraryFolders = """
-        "libraryfolders"
-        {
-            "0"
-            {
-                "path"      "C:\\Program Files (x86)\\Steam"
-                "apps"
-                {
-                    "730"       "35241502720"
-                    "570"       "28000000000"
-                }
-            }
-            "1"
-            {
-                "path"      "D:\\SteamLibrary"
-                "apps"
-                {
-                    "292030"    "50000000000"
-                }
-            }
-        }
-        """;
-
-    private const string SampleAppManifest = """
-        "AppState"
-        {
-            "appid"         "730"
-            "name"          "Counter-Strike 2"
-            "StateFlags"    "4"
-            "installdir"    "Counter-Strike Global Offensive"
-            "LastUpdated"   "1700000000"
-        }
-        """;
-
     private readonly ISteamPlatform _platform = A.Fake<ISteamPlatform>();
 
     private SteamService CreateService() => new(_platform);
@@ -49,7 +15,7 @@ public class SteamServiceTests
     [Fact]
     public void ParseLibraryFolders_ValidVdf_ReturnsLibraryPaths()
     {
-        var paths = SteamService.ParseLibraryFolders(SampleLibraryFolders);
+        var paths = SteamService.ParseLibraryFolders(TestData.Load("library-folders.vdf"));
 
         paths.Count.ShouldBe(2);
         paths[0].ShouldBe(@"C:\Program Files (x86)\Steam");
@@ -75,7 +41,7 @@ public class SteamServiceTests
     [Fact]
     public void ParseAppManifest_ValidAcf_ReturnsGameInfo()
     {
-        var game = SteamService.ParseAppManifest(SampleAppManifest);
+        var game = SteamService.ParseAppManifest(TestData.Load("app-manifest-730.acf"));
 
         game.ShouldNotBeNull();
         game.AppId.ShouldBe(730);
@@ -153,7 +119,7 @@ public class SteamServiceTests
     [Fact]
     public void ParseInstallDir_ValidAcf_ReturnsInstallDir()
     {
-        var installDir = SteamService.ParseInstallDir(SampleAppManifest);
+        var installDir = SteamService.ParseInstallDir(TestData.Load("app-manifest-730.acf"));
 
         installDir.ShouldBe("Counter-Strike Global Offensive");
     }

--- a/tests/HaPcRemote.Service.Tests/TestData.cs
+++ b/tests/HaPcRemote.Service.Tests/TestData.cs
@@ -1,0 +1,9 @@
+namespace HaPcRemote.Service.Tests;
+
+internal static class TestData
+{
+    public static string Load(string fileName) =>
+        File.ReadAllText(Path.Combine(
+            Path.GetDirectoryName(typeof(TestData).Assembly.Location)!,
+            "TestData", fileName));
+}

--- a/tests/HaPcRemote.Service.Tests/TestData/app-manifest-730.acf
+++ b/tests/HaPcRemote.Service.Tests/TestData/app-manifest-730.acf
@@ -1,0 +1,8 @@
+"AppState"
+{
+    "appid"         "730"
+    "name"          "Counter-Strike 2"
+    "StateFlags"    "4"
+    "installdir"    "Counter-Strike Global Offensive"
+    "LastUpdated"   "1700000000"
+}

--- a/tests/HaPcRemote.Service.Tests/TestData/library-folders.vdf
+++ b/tests/HaPcRemote.Service.Tests/TestData/library-folders.vdf
@@ -1,0 +1,20 @@
+"libraryfolders"
+{
+    "0"
+    {
+        "path"      "C:\\Program Files (x86)\\Steam"
+        "apps"
+        {
+            "730"       "35241502720"
+            "570"       "28000000000"
+        }
+    }
+    "1"
+    {
+        "path"      "D:\\SteamLibrary"
+        "apps"
+        {
+            "292030"    "50000000000"
+        }
+    }
+}

--- a/tests/HaPcRemote.Service.Tests/TestData/monitors-disconnected.xml
+++ b/tests/HaPcRemote.Service.Tests/TestData/monitors-disconnected.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<monitors_list>
+<item>
+<resolution>3840 X 2160</resolution>
+<active>Yes</active>
+<disconnected>No</disconnected>
+<primary>Yes</primary>
+<frequency>144</frequency>
+<name>\\.\DISPLAY1</name>
+<short_monitor_id>GSM59A4</short_monitor_id>
+<monitor_name>LG ULTRAGEAR</monitor_name>
+<monitor_serial_number>ABC123</monitor_serial_number>
+</item>
+<item>
+<resolution></resolution>
+<active>No</active>
+<disconnected>Yes</disconnected>
+<primary>No</primary>
+<frequency>0</frequency>
+<name>\\.\DISPLAY4</name>
+<short_monitor_id>AOC1234</short_monitor_id>
+<monitor_name>AOC Monitor</monitor_name>
+<monitor_serial_number>DISC01</monitor_serial_number>
+</item>
+</monitors_list>

--- a/tests/HaPcRemote.Service.Tests/TestData/monitors-inactive-target.xml
+++ b/tests/HaPcRemote.Service.Tests/TestData/monitors-inactive-target.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<monitors_list>
+<item>
+<resolution>3840 X 2160</resolution>
+<active>Yes</active>
+<disconnected>No</disconnected>
+<primary>Yes</primary>
+<frequency>144</frequency>
+<name>\\.\DISPLAY1</name>
+<short_monitor_id>GSM59A4</short_monitor_id>
+<monitor_name>LG ULTRAGEAR</monitor_name>
+<monitor_serial_number>ABC123</monitor_serial_number>
+</item>
+<item>
+<resolution>2560 X 1440</resolution>
+<active>No</active>
+<disconnected>No</disconnected>
+<primary>No</primary>
+<frequency>60</frequency>
+<name>\\.\DISPLAY2</name>
+<short_monitor_id>DEL4321</short_monitor_id>
+<monitor_name>Dell U2723QE</monitor_name>
+<monitor_serial_number>XYZ789</monitor_serial_number>
+</item>
+</monitors_list>

--- a/tests/HaPcRemote.Service.Tests/TestData/monitors-sample.xml
+++ b/tests/HaPcRemote.Service.Tests/TestData/monitors-sample.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" ?>
+<monitors_list>
+<item>
+<resolution>3840 X 2160</resolution>
+<left-top>0, 0</left-top>
+<right-bottom>3840, 2160</right-bottom>
+<active>Yes</active>
+<disconnected>No</disconnected>
+<primary>Yes</primary>
+<colors>32</colors>
+<frequency>144</frequency>
+<orientation>Default</orientation>
+<maximum_resolution>3840 X 2160</maximum_resolution>
+<current_scale>100%</current_scale>
+<maximum_scale>200%</maximum_scale>
+<name>\\.\DISPLAY1</name>
+<adapter>NVIDIA GeForce</adapter>
+<device_id>PCI\VEN_10DE</device_id>
+<device_key>\Registry\Machine\System\CurrentControlSet\Control\Video\{ABC}\0000</device_key>
+<monitor_id>MONITOR\GSM59A4\{4d36e96e-e325-11ce-bfc1-08002be10318}\0001</monitor_id>
+<short_monitor_id>GSM59A4</short_monitor_id>
+<monitor_key>\Registry\Machine\System\CurrentControlSet\Control\Class\{4d36e96e}\0001</monitor_key>
+<monitor_string>LG ULTRAGEAR</monitor_string>
+<monitor_name>LG ULTRAGEAR</monitor_name>
+<monitor_serial_number>ABC123</monitor_serial_number>
+</item>
+<item>
+<resolution>2560 X 1440</resolution>
+<left-top>3840, 0</left-top>
+<right-bottom>6400, 1440</right-bottom>
+<active>Yes</active>
+<disconnected>No</disconnected>
+<primary>No</primary>
+<colors>32</colors>
+<frequency>60</frequency>
+<orientation>Default</orientation>
+<maximum_resolution>2560 X 1440</maximum_resolution>
+<current_scale>100%</current_scale>
+<maximum_scale>200%</maximum_scale>
+<name>\\.\DISPLAY2</name>
+<adapter>NVIDIA GeForce</adapter>
+<device_id>PCI\VEN_10DE</device_id>
+<device_key>\Registry\Machine\System\CurrentControlSet\Control\Video\{DEF}\0001</device_key>
+<monitor_id>MONITOR\DEL4321\{4d36e96e-e325-11ce-bfc1-08002be10318}\0002</monitor_id>
+<short_monitor_id>DEL4321</short_monitor_id>
+<monitor_key>\Registry\Machine\System\CurrentControlSet\Control\Class\{4d36e96e}\0002</monitor_key>
+<monitor_string>Dell U2723QE</monitor_string>
+<monitor_name>Dell U2723QE</monitor_name>
+<monitor_serial_number>XYZ789</monitor_serial_number>
+</item>
+<item>
+<resolution>1920 X 1080</resolution>
+<left-top>6400, 0</left-top>
+<right-bottom>8320, 1080</right-bottom>
+<active>Yes</active>
+<disconnected>No</disconnected>
+<primary>No</primary>
+<colors>32</colors>
+<frequency>240</frequency>
+<orientation>Default</orientation>
+<maximum_resolution>1920 X 1080</maximum_resolution>
+<current_scale>100%</current_scale>
+<maximum_scale>200%</maximum_scale>
+<name>\\.\DISPLAY3</name>
+<adapter>NVIDIA GeForce</adapter>
+<device_id>PCI\VEN_10DE</device_id>
+<device_key>\Registry\Machine\System\CurrentControlSet\Control\Video\{GHI}\0002</device_key>
+<monitor_id>MONITOR\SAM0F00\{4d36e96e-e325-11ce-bfc1-08002be10318}\0003</monitor_id>
+<short_monitor_id>SAM0F00</short_monitor_id>
+<monitor_key>\Registry\Machine\System\CurrentControlSet\Control\Class\{4d36e96e}\0003</monitor_key>
+<monitor_string>Samsung Odyssey</monitor_string>
+<monitor_name>Samsung Odyssey</monitor_name>
+<monitor_serial_number></monitor_serial_number>
+</item>
+</monitors_list>


### PR DESCRIPTION
## Summary
- Refactor 11 service/middleware/IPC classes to C# 12 primary constructors (`AudioService`, `AppService`, `MonitorService`, `SteamService`, `IpcSteamPlatform`, `TrayCliRunner`, `TrayAppLauncher`, `MdnsAdvertiserService`, `ApiKeyMiddleware`, `IpcServer`, `IpcRequestHandler`)
- Extract large inline test data strings (10+ lines) to `TestData/` files with `CopyToOutputDirectory=Always`
- Fix pre-existing nullable reference errors (CS8604) in test assertions

## Test plan
- [ ] 154 unit tests pass
- [ ] CI build passes