### PR TITLE
feat: user idle time endpoint (v1.0.2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ All endpoints except `/api/health` require the `X-Api-Key` header.
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| `GET` | `/api/system/state` | All state in one call (audio, monitors, Steam, modes) |
+| `GET` | `/api/system/state` | All state in one call (audio, monitors, Steam, modes, idle) |
 | `GET` | `/api/system/modes` | List available PC mode names |
+| `GET` | `/api/system/idle` | Seconds since last keyboard/mouse input |
 | `POST` | `/api/system/mode/{name}` | Apply a named PC mode |
 | `POST` | `/api/system/sleep` | Suspend the PC |
 
@@ -225,8 +226,8 @@ dotnet publish src/HaPcRemote.Headless -c Release -r linux-x64
 - [x] Linux headless daemon + systemd user service *(v0.9.5)*
 - [x] PC Mode endpoint + HA select entity *(v1.0)*
 - [x] Aggregated state endpoint `GET /api/system/state` *(v1.0)*
+- [x] User Idle Time endpoint `GET /api/system/idle` *(v1.0.2)*
 - [x] Brand icons submitted to [home-assistant/brands](https://github.com/home-assistant/brands) *(awaiting approval)*
-- [ ] User Idle Time sensor `GET /api/system/idle` *(v1.1)*
 
 ## License
 

--- a/src/HaPcRemote.Core/AppJsonContext.cs
+++ b/src/HaPcRemote.Core/AppJsonContext.cs
@@ -30,6 +30,8 @@ namespace HaPcRemote.Service;
 [JsonSerializable(typeof(ApiResponse<SteamRunningGame>))]
 [JsonSerializable(typeof(IReadOnlyList<string>))]
 [JsonSerializable(typeof(ApiResponse<IReadOnlyList<string>>))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(ApiResponse<int>))]
 [JsonSerializable(typeof(AudioState))]
 [JsonSerializable(typeof(SystemState))]
 [JsonSerializable(typeof(ApiResponse<SystemState>))]

--- a/src/HaPcRemote.Core/Endpoints/SystemEndpoints.cs
+++ b/src/HaPcRemote.Core/Endpoints/SystemEndpoints.cs
@@ -18,6 +18,12 @@ public static class SystemEndpoints
             return Results.Json(ApiResponse.Ok("Sleep initiated"), AppJsonContext.Default.ApiResponse);
         });
 
+        group.MapGet("/idle", (IIdleService idleService) =>
+        {
+            var seconds = idleService.GetIdleSeconds();
+            return Results.Json(ApiResponse.Ok(seconds), AppJsonContext.Default.ApiResponseInt32);
+        });
+
         return group;
     }
 }

--- a/src/HaPcRemote.Core/Endpoints/SystemStateEndpoints.cs
+++ b/src/HaPcRemote.Core/Endpoints/SystemStateEndpoints.cs
@@ -12,6 +12,7 @@ public static class SystemStateEndpoints
             IMonitorService monitorService,
             SteamService steamService,
             ModeService modeService,
+            IIdleService idleService,
             ILogger<SystemState> logger) =>
         {
             // Fire all async calls concurrently
@@ -49,6 +50,10 @@ public static class SystemStateEndpoints
             try { modes = modeService.GetModeNames().ToList(); }
             catch (Exception ex) { logger.LogWarning(ex, "Failed to get modes"); }
 
+            int? idleSeconds = null;
+            try { idleSeconds = idleService.GetIdleSeconds(); }
+            catch (Exception ex) { logger.LogWarning(ex, "Failed to get idle time"); }
+
             var state = new SystemState
             {
                 Audio = audio,
@@ -56,7 +61,8 @@ public static class SystemStateEndpoints
                 MonitorProfiles = monitorProfiles,
                 SteamGames = steamGames,
                 RunningGame = runningGame,
-                Modes = modes
+                Modes = modes,
+                IdleSeconds = idleSeconds
             };
 
             return Results.Json(

--- a/src/HaPcRemote.Core/Models/SystemState.cs
+++ b/src/HaPcRemote.Core/Models/SystemState.cs
@@ -8,6 +8,7 @@ public sealed class SystemState
     public List<SteamGame>? SteamGames { get; init; }
     public SteamRunningGame? RunningGame { get; init; }
     public List<string>? Modes { get; init; }
+    public int? IdleSeconds { get; init; }
 }
 
 public sealed class AudioState

--- a/src/HaPcRemote.Core/Services/IIdleService.cs
+++ b/src/HaPcRemote.Core/Services/IIdleService.cs
@@ -1,0 +1,9 @@
+namespace HaPcRemote.Service.Services;
+
+public interface IIdleService
+{
+    /// <summary>
+    /// Returns the number of seconds since the last user input (keyboard/mouse).
+    /// </summary>
+    int GetIdleSeconds();
+}

--- a/src/HaPcRemote.Core/Services/LinuxIdleService.cs
+++ b/src/HaPcRemote.Core/Services/LinuxIdleService.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+namespace HaPcRemote.Service.Services;
+
+[SupportedOSPlatform("linux")]
+public sealed class LinuxIdleService(ILogger<LinuxIdleService> logger) : IIdleService
+{
+    public int GetIdleSeconds()
+    {
+        // xprintidle returns milliseconds since last X11 input event
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "xprintidle",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true
+            });
+
+            if (process is null) return 0;
+
+            var output = process.StandardOutput.ReadToEnd().Trim();
+            process.WaitForExit();
+
+            if (process.ExitCode == 0 && int.TryParse(output, out var ms))
+                return ms / 1000;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "xprintidle not available");
+        }
+
+        return 0;
+    }
+}

--- a/src/HaPcRemote.Core/Services/WindowsIdleService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsIdleService.cs
@@ -1,0 +1,29 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace HaPcRemote.Service.Services;
+
+[SupportedOSPlatform("windows")]
+public sealed partial class WindowsIdleService : IIdleService
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct LASTINPUTINFO
+    {
+        public uint cbSize;
+        public uint dwTime;
+    }
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetLastInputInfo(ref LASTINPUTINFO plii);
+
+    public int GetIdleSeconds()
+    {
+        var info = new LASTINPUTINFO { cbSize = (uint)Marshal.SizeOf<LASTINPUTINFO>() };
+        if (!GetLastInputInfo(ref info))
+            return 0;
+
+        var idleMs = (uint)Environment.TickCount - info.dwTime;
+        return (int)(idleMs / 1000);
+    }
+}

--- a/src/HaPcRemote.Headless/Program.cs
+++ b/src/HaPcRemote.Headless/Program.cs
@@ -86,6 +86,7 @@ builder.Services.AddSingleton<IMonitorService, LinuxMonitorService>();
 builder.Services.AddSingleton<ModeService>();
 builder.Services.AddHostedService<MdnsAdvertiserService>();
 builder.Services.AddSingleton<IPowerService, LinuxPowerService>();
+builder.Services.AddSingleton<IIdleService, LinuxIdleService>();
 builder.Services.AddSingleton<ISteamPlatform, LinuxSteamPlatform>();
 builder.Services.AddSingleton<SteamService>();
 

--- a/src/HaPcRemote.Tray/TrayWebHost.cs
+++ b/src/HaPcRemote.Tray/TrayWebHost.cs
@@ -87,6 +87,7 @@ internal static class TrayWebHost
         builder.Services.AddSingleton<ModeService>();
         builder.Services.AddHostedService<MdnsAdvertiserService>();
         builder.Services.AddSingleton<IPowerService, WindowsPowerService>();
+        builder.Services.AddSingleton<IIdleService, WindowsIdleService>();
         builder.Services.AddSingleton<ISteamPlatform, WindowsSteamPlatform>();
         builder.Services.AddSingleton<SteamService>();
 

--- a/tests/HaPcRemote.Service.Tests/Endpoints/EndpointTestBase.cs
+++ b/tests/HaPcRemote.Service.Tests/Endpoints/EndpointTestBase.cs
@@ -20,6 +20,7 @@ public class EndpointTestBase : IAsyncLifetime
     protected readonly ISteamPlatform SteamPlatform = A.Fake<ISteamPlatform>();
     protected readonly IAudioService AudioService = A.Fake<IAudioService>();
     protected readonly IMonitorService MonitorService = A.Fake<IMonitorService>();
+    protected readonly IIdleService IdleService = A.Fake<IIdleService>();
 
     private WebApplication? _app;
 
@@ -47,6 +48,7 @@ public class EndpointTestBase : IAsyncLifetime
         builder.Services.AddSingleton(SteamPlatform);
         builder.Services.AddSingleton<IAudioService>(AudioService);
         builder.Services.AddSingleton<IMonitorService>(MonitorService);
+        builder.Services.AddSingleton(IdleService);
 
         // Real services that delegate to fakes
         builder.Services.AddSingleton<AppService>();

--- a/tests/HaPcRemote.Service.Tests/Endpoints/SystemEndpointTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Endpoints/SystemEndpointTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
+using System.Net.Http.Json;
 using FakeItEasy;
 using HaPcRemote.Service.Models;
-using HaPcRemote.Service.Services;
 using Shouldly;
 
 namespace HaPcRemote.Service.Tests.Endpoints;
@@ -27,6 +27,34 @@ public class SystemEndpointTests : EndpointTestBase
         using var client = CreateClient();
 
         var response = await client.PostAsync("/api/system/sleep", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
+    }
+
+    [Fact]
+    public async Task Idle_ReturnsSeconds()
+    {
+        A.CallTo(() => IdleService.GetIdleSeconds()).Returns(42);
+        using var client = CreateClient();
+
+        var response = await client.GetAsync("/api/system/idle");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var json = await response.Content.ReadFromJsonAsync<ApiResponse<int>>(
+            AppJsonContext.Default.ApiResponseInt32);
+        json.ShouldNotBeNull();
+        json.Success.ShouldBeTrue();
+        json.Data.ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task Idle_ServiceThrows_Returns500()
+    {
+        A.CallTo(() => IdleService.GetIdleSeconds())
+            .Throws(new InvalidOperationException("no idle service"));
+        using var client = CreateClient();
+
+        var response = await client.GetAsync("/api/system/idle");
 
         response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
     }

--- a/tests/HaPcRemote.Service.Tests/Endpoints/SystemStateEndpointTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Endpoints/SystemStateEndpointTests.cs
@@ -133,6 +133,35 @@ public class SystemStateEndpointTests : EndpointTestBase
     }
 
     [Fact]
+    public async Task GetState_IdleAvailable_PopulatesIdleSeconds()
+    {
+        SetupDefaults();
+        A.CallTo(() => IdleService.GetIdleSeconds()).Returns(120);
+        using var client = CreateClient();
+
+        var response = await client.GetAsync("/api/system/state");
+
+        var json = await response.Content.ReadFromJsonAsync<ApiResponse<SystemState>>(
+            AppJsonContext.Default.ApiResponseSystemState);
+        json!.Data!.IdleSeconds.ShouldBe(120);
+    }
+
+    [Fact]
+    public async Task GetState_IdleFails_IdleSecondsIsNull()
+    {
+        SetupDefaults();
+        A.CallTo(() => IdleService.GetIdleSeconds())
+            .Throws(new InvalidOperationException("no idle"));
+        using var client = CreateClient();
+
+        var response = await client.GetAsync("/api/system/state");
+
+        var json = await response.Content.ReadFromJsonAsync<ApiResponse<SystemState>>(
+            AppJsonContext.Default.ApiResponseSystemState);
+        json!.Data!.IdleSeconds.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task GetState_AlwaysReturnsSuccessTrue()
     {
         A.CallTo(() => AudioService.GetDevicesAsync())


### PR DESCRIPTION
## Summary
- Add `GET /api/system/idle` endpoint returning seconds since last keyboard/mouse input
- Windows: `GetLastInputInfo` Win32 API via P/Invoke
- Linux: `xprintidle` command
- Included in aggregated `GET /api/system/state` response as `idleSeconds`
- Version bump to 1.0.2

## Test plan
- [x] 195 tests pass locally (4 new idle tests)