### PR TITLE
fix: headless build error

### DIFF
--- a/src/HaPcRemote.Headless/Program.cs
+++ b/src/HaPcRemote.Headless/Program.cs
@@ -109,7 +109,7 @@ app.Use(async (context, next) =>
             context.Response.ContentType = "application/json";
             await context.Response.WriteAsJsonAsync(
                 ApiResponse.Fail("Internal server error"),
-                AppJsonContext.Default.ApiResponse,
+                AppJsonContext.Default.Options,
                 context.RequestAborted);
         }
     }


### PR DESCRIPTION
## Summary
- Fix `WriteAsJsonAsync` overload resolution in Headless Program.cs
- Use `AppJsonContext.Default.Options` instead of `AppJsonContext.Default.ApiResponse` for `JsonSerializerOptions` parameter

## Test plan
- [x] Headless builds cleanly with `dotnet build -c Release`
- [x] 195 tests pass