### PR TITLE
refactor: v1.0.3 code review fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,8 @@ dotnet publish src/HaPcRemote.Tray -c Release -r win-x64
 dotnet publish src/HaPcRemote.Headless -c Release -r linux-x64
 ```
 
-## Known issues
-- favicon: [15.12.23] [WRN] ApiKeyMiddleware - Request to /api/steam/running missing API key
-[15.12.23] [WRN] ApiKeyMiddleware - Request to /favicon.ico missing API key
+## Known Issues
+- Browsers hitting the service URL directly trigger API key warnings for `/favicon.ico` requests
 
 ## Roadmap
 

--- a/src/HaPcRemote.Core/Endpoints/ModeEndpoints.cs
+++ b/src/HaPcRemote.Core/Endpoints/ModeEndpoints.cs
@@ -8,7 +8,7 @@ public static class ModeEndpoints
 {
     public static IEndpointRouteBuilder MapModeEndpoints(this IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGet("/api/system/modes", (ModeService modeService) =>
+        endpoints.MapGet("/api/system/modes", (IModeService modeService) =>
         {
             var names = modeService.GetModeNames();
             return Results.Json(
@@ -16,7 +16,7 @@ public static class ModeEndpoints
                 AppJsonContext.Default.ApiResponseIReadOnlyListString);
         }).AddEndpointFilter<EndpointExceptionFilter>();
 
-        endpoints.MapPost("/api/system/mode/{modeName}", async (string modeName, ModeService modeService,
+        endpoints.MapPost("/api/system/mode/{modeName}", async (string modeName, IModeService modeService,
             ILogger<ModeService> logger) =>
         {
             logger.LogInformation("Apply mode '{ModeName}' requested", modeName);

--- a/src/HaPcRemote.Core/Endpoints/SteamEndpoints.cs
+++ b/src/HaPcRemote.Core/Endpoints/SteamEndpoints.cs
@@ -11,7 +11,7 @@ public static class SteamEndpoints
         var group = endpoints.MapGroup("/api/steam");
         group.AddEndpointFilter<EndpointExceptionFilter>();
 
-        group.MapGet("/games", async (SteamService steamService) =>
+        group.MapGet("/games", async (ISteamService steamService) =>
         {
             var games = await steamService.GetGamesAsync();
             return Results.Json(
@@ -19,7 +19,7 @@ public static class SteamEndpoints
                 AppJsonContext.Default.ApiResponseListSteamGame);
         });
 
-        group.MapGet("/running", async (SteamService steamService) =>
+        group.MapGet("/running", async (ISteamService steamService) =>
         {
             var running = await steamService.GetRunningGameAsync();
             return Results.Json(
@@ -27,7 +27,7 @@ public static class SteamEndpoints
                 AppJsonContext.Default.ApiResponseSteamRunningGame);
         });
 
-        group.MapPost("/run/{appId:int}", async (int appId, SteamService steamService,
+        group.MapPost("/run/{appId:int}", async (int appId, ISteamService steamService,
             ILogger<SteamService> logger) =>
         {
             logger.LogInformation("Launch Steam game requested: {AppId}", appId);
@@ -37,7 +37,7 @@ public static class SteamEndpoints
                 AppJsonContext.Default.ApiResponseSteamRunningGame);
         });
 
-        group.MapPost("/stop", async (SteamService steamService, ILogger<SteamService> logger) =>
+        group.MapPost("/stop", async (ISteamService steamService, ILogger<SteamService> logger) =>
         {
             logger.LogInformation("Stop Steam game requested");
             await steamService.StopGameAsync();

--- a/src/HaPcRemote.Core/Endpoints/SystemEndpoints.cs
+++ b/src/HaPcRemote.Core/Endpoints/SystemEndpoints.cs
@@ -21,7 +21,12 @@ public static class SystemEndpoints
         group.MapGet("/idle", (IIdleService idleService) =>
         {
             var seconds = idleService.GetIdleSeconds();
-            return Results.Json(ApiResponse.Ok(seconds), AppJsonContext.Default.ApiResponseInt32);
+            if (seconds is null)
+                return Results.Json(
+                    ApiResponse.Fail("Idle detection unavailable"),
+                    AppJsonContext.Default.ApiResponse,
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            return Results.Json(ApiResponse.Ok(seconds.Value), AppJsonContext.Default.ApiResponseInt32);
         });
 
         return group;

--- a/src/HaPcRemote.Core/Endpoints/SystemStateEndpoints.cs
+++ b/src/HaPcRemote.Core/Endpoints/SystemStateEndpoints.cs
@@ -10,8 +10,8 @@ public static class SystemStateEndpoints
         endpoints.MapGet("/api/system/state", async (
             IAudioService audioService,
             IMonitorService monitorService,
-            SteamService steamService,
-            ModeService modeService,
+            ISteamService steamService,
+            IModeService modeService,
             IIdleService idleService,
             ILogger<SystemState> logger) =>
         {

--- a/src/HaPcRemote.Core/Services/IIdleService.cs
+++ b/src/HaPcRemote.Core/Services/IIdleService.cs
@@ -3,7 +3,8 @@ namespace HaPcRemote.Service.Services;
 public interface IIdleService
 {
     /// <summary>
-    /// Returns the number of seconds since the last user input (keyboard/mouse).
+    /// Returns the number of seconds since the last user input (keyboard/mouse),
+    /// or null if idle detection is unavailable.
     /// </summary>
-    int GetIdleSeconds();
+    int? GetIdleSeconds();
 }

--- a/src/HaPcRemote.Core/Services/IModeService.cs
+++ b/src/HaPcRemote.Core/Services/IModeService.cs
@@ -1,0 +1,7 @@
+namespace HaPcRemote.Service.Services;
+
+public interface IModeService
+{
+    IReadOnlyList<string> GetModeNames();
+    Task ApplyModeAsync(string modeName);
+}

--- a/src/HaPcRemote.Core/Services/ISteamService.cs
+++ b/src/HaPcRemote.Core/Services/ISteamService.cs
@@ -1,0 +1,11 @@
+using HaPcRemote.Service.Models;
+
+namespace HaPcRemote.Service.Services;
+
+public interface ISteamService
+{
+    Task<List<SteamGame>> GetGamesAsync();
+    Task<SteamRunningGame?> GetRunningGameAsync();
+    Task<SteamRunningGame?> LaunchGameAsync(int appId);
+    Task StopGameAsync();
+}

--- a/src/HaPcRemote.Core/Services/LinuxIdleService.cs
+++ b/src/HaPcRemote.Core/Services/LinuxIdleService.cs
@@ -6,7 +6,7 @@ namespace HaPcRemote.Service.Services;
 [SupportedOSPlatform("linux")]
 public sealed class LinuxIdleService(ILogger<LinuxIdleService> logger) : IIdleService
 {
-    public int GetIdleSeconds()
+    public int? GetIdleSeconds()
     {
         // xprintidle returns milliseconds since last X11 input event
         try
@@ -19,7 +19,7 @@ public sealed class LinuxIdleService(ILogger<LinuxIdleService> logger) : IIdleSe
                 CreateNoWindow = true
             });
 
-            if (process is null) return 0;
+            if (process is null) return null;
 
             var output = process.StandardOutput.ReadToEnd().Trim();
             process.WaitForExit();
@@ -32,6 +32,6 @@ public sealed class LinuxIdleService(ILogger<LinuxIdleService> logger) : IIdleSe
             logger.LogDebug(ex, "xprintidle not available");
         }
 
-        return 0;
+        return null;
     }
 }

--- a/src/HaPcRemote.Core/Services/ModeService.cs
+++ b/src/HaPcRemote.Core/Services/ModeService.cs
@@ -7,7 +7,7 @@ public class ModeService(
     IOptionsMonitor<PcRemoteOptions> options,
     IAudioService audioService,
     IMonitorService monitorService,
-    AppService appService)
+    AppService appService) : IModeService
 {
     public IReadOnlyList<string> GetModeNames() =>
         options.CurrentValue.Modes.Keys.ToList();

--- a/src/HaPcRemote.Core/Services/SteamService.cs
+++ b/src/HaPcRemote.Core/Services/SteamService.cs
@@ -3,7 +3,7 @@ using ValveKeyValue;
 
 namespace HaPcRemote.Service.Services;
 
-public class SteamService(ISteamPlatform platform)
+public class SteamService(ISteamPlatform platform) : ISteamService
 {
     private List<SteamGame>? _cachedGames;
     private DateTime _cacheExpiry;

--- a/src/HaPcRemote.Core/Services/WindowsIdleService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsIdleService.cs
@@ -17,11 +17,11 @@ public sealed partial class WindowsIdleService : IIdleService
     [return: MarshalAs(UnmanagedType.Bool)]
     private static partial bool GetLastInputInfo(ref LASTINPUTINFO plii);
 
-    public int GetIdleSeconds()
+    public int? GetIdleSeconds()
     {
         var info = new LASTINPUTINFO { cbSize = (uint)Marshal.SizeOf<LASTINPUTINFO>() };
         if (!GetLastInputInfo(ref info))
-            return 0;
+            return null;
 
         var idleMs = (uint)Environment.TickCount - info.dwTime;
         return (int)(idleMs / 1000);

--- a/src/HaPcRemote.Headless/Program.cs
+++ b/src/HaPcRemote.Headless/Program.cs
@@ -83,12 +83,12 @@ builder.Services.AddSingleton<IAppLauncher, DirectAppLauncher>();
 builder.Services.AddSingleton<AppService>();
 builder.Services.AddSingleton<IAudioService, LinuxAudioService>();
 builder.Services.AddSingleton<IMonitorService, LinuxMonitorService>();
-builder.Services.AddSingleton<ModeService>();
+builder.Services.AddSingleton<IModeService, ModeService>();
 builder.Services.AddHostedService<MdnsAdvertiserService>();
 builder.Services.AddSingleton<IPowerService, LinuxPowerService>();
 builder.Services.AddSingleton<IIdleService, LinuxIdleService>();
 builder.Services.AddSingleton<ISteamPlatform, LinuxSteamPlatform>();
-builder.Services.AddSingleton<SteamService>();
+builder.Services.AddSingleton<ISteamService, SteamService>();
 
 var app = builder.Build();
 

--- a/src/HaPcRemote.Tray/TrayWebHost.cs
+++ b/src/HaPcRemote.Tray/TrayWebHost.cs
@@ -84,12 +84,12 @@ internal static class TrayWebHost
         builder.Services.AddSingleton<AppService>();
         builder.Services.AddSingleton<IAudioService, AudioService>();
         builder.Services.AddSingleton<IMonitorService, MonitorService>();
-        builder.Services.AddSingleton<ModeService>();
+        builder.Services.AddSingleton<IModeService, ModeService>();
         builder.Services.AddHostedService<MdnsAdvertiserService>();
         builder.Services.AddSingleton<IPowerService, WindowsPowerService>();
         builder.Services.AddSingleton<IIdleService, WindowsIdleService>();
         builder.Services.AddSingleton<ISteamPlatform, WindowsSteamPlatform>();
-        builder.Services.AddSingleton<SteamService>();
+        builder.Services.AddSingleton<ISteamService, SteamService>();
 
         var app = builder.Build();
 

--- a/tests/HaPcRemote.Service.Tests/Endpoints/EndpointTestBase.cs
+++ b/tests/HaPcRemote.Service.Tests/Endpoints/EndpointTestBase.cs
@@ -52,8 +52,8 @@ public class EndpointTestBase : IAsyncLifetime
 
         // Real services that delegate to fakes
         builder.Services.AddSingleton<AppService>();
-        builder.Services.AddSingleton<ModeService>();
-        builder.Services.AddSingleton<SteamService>();
+        builder.Services.AddSingleton<IModeService, ModeService>();
+        builder.Services.AddSingleton<ISteamService, SteamService>();
         // MdnsAdvertiserService excluded — avoids UDP socket binding in tests
 
         _app = builder.Build();

--- a/tests/HaPcRemote.Service.Tests/Endpoints/SystemEndpointTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Endpoints/SystemEndpointTests.cs
@@ -48,6 +48,17 @@ public class SystemEndpointTests : EndpointTestBase
     }
 
     [Fact]
+    public async Task Idle_Unavailable_Returns503()
+    {
+        A.CallTo(() => IdleService.GetIdleSeconds()).Returns((int?)null);
+        using var client = CreateClient();
+
+        var response = await client.GetAsync("/api/system/idle");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
     public async Task Idle_ServiceThrows_Returns500()
     {
         A.CallTo(() => IdleService.GetIdleSeconds())


### PR DESCRIPTION
## Summary
- `IIdleService.GetIdleSeconds()` returns `int?` — `null` means unavailable (was silently returning 0)
- `GET /api/system/idle` returns 503 when idle detection is unavailable
- Extract `ISteamService` and `IModeService` interfaces for consistent DI across all endpoints
- Clean up README known issues section (was raw log output)

## Test plan
- [x] 196 unit tests passing
- [ ] Verify `/api/system/idle` returns 503 when xprintidle missing (Linux)