### PR TITLE
feat: suppress framework request logging, bump v1.0.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
   </PropertyGroup>
 </Project>

--- a/src/HaPcRemote.Headless/Program.cs
+++ b/src/HaPcRemote.Headless/Program.cs
@@ -14,6 +14,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Logging — console (captured by journalctl) + file
 builder.Logging.ClearProviders();
+builder.Logging.AddFilter("Microsoft.AspNetCore", LogLevel.Warning);
 builder.Logging.AddConsole();
 builder.Logging.AddProvider(new FileLoggerProvider(ConfigPaths.GetLogFilePath()));
 

--- a/src/HaPcRemote.Tray/TrayWebHost.cs
+++ b/src/HaPcRemote.Tray/TrayWebHost.cs
@@ -19,6 +19,7 @@ internal static class TrayWebHost
 
         // Logging — file + in-memory (shared with tray log viewer)
         builder.Logging.ClearProviders();
+        builder.Logging.AddFilter("Microsoft.AspNetCore", LogLevel.Warning);
         builder.Logging.AddProvider(new FileLoggerProvider(ConfigPaths.GetLogFilePath()));
         builder.Logging.AddProvider(logProvider);
 


### PR DESCRIPTION
## Summary
- Filter `Microsoft.AspNetCore` logs to Warning level in both Tray and Headless hosts
- Eliminates noisy INFO logs from health/state polling (Diagnostics, EndpointMiddleware, JsonResult)
- App-level Info logs (e.g. "Sleep requested") are unaffected
- Bump version to 1.0.3

## Test plan
- [x] 196 tests pass
- [ ] Verify health/state polling no longer produces INFO framework logs
- [ ] Verify action endpoints still log at app level