### PR TITLE
fix: skip auth for non-API paths, use LastPlayed for Steam sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,18 +218,11 @@ dotnet publish src/HaPcRemote.Headless -c Release -r linux-x64
 ## Known Issues
 - Browsers hitting the service URL directly trigger API key warnings for `/favicon.ico` requests
 - Top 20 isnt working correctly, shows games that hasnt been played since 2022. Need to introduce some debug discovery code or review our approach of sorting the steam files.
-- Game Images comes in variting size / format. If possible investigate compatiblity with home assistant Poster's prefered else square.
+- ~Game images varying size/format~ — **Resolved**: switched from `header.jpg` (460x215 landscape) to `library_600x900.jpg` (600x900 portrait poster) matching HA media browser expectations.
 - Non-steam games arent compatible and cannot so far be launched - theres also the issue of how to get posters for these games, could they be extracted from steam or another free fallback solution?
 - When user manually checks for update and quickly clicks the green update button, the tray will show a console error of the file is already in use (this is due to auto update triggered right after and colliding with user update, a low priority to solve)
 - Update button shouldnt be green, just regular colors
-- Entity turn on and off broken:
-```Logger: homeassistant.helpers.script.pc_turn_off
-Source: helpers/script.py:2098
-First occurred: 18:19:09 (3 occurrences)
-Last logged: 19:25:50
-
-PC turn_off: Error executing script. Invalid data for call_service at pos 1: extra keys not allowed @ data['input']
-```
+- ~Entity turn on and off broken~ — **Resolved**: the error `extra keys not allowed @ data['input']` was from a user-defined script using `!input` syntax (a blueprint-only feature) in a regular script. The entity `async_turn_on`/`async_turn_off` methods work correctly. If you see this error, check your scripts for `!input` usage and replace with literal entity IDs or use `target:` instead of `data:`.
 ## Roadmap
 
 - [ ] Introduce config panel with multiple tabs

--- a/src/HaPcRemote.Core/Middleware/ApiKeyMiddleware.cs
+++ b/src/HaPcRemote.Core/Middleware/ApiKeyMiddleware.cs
@@ -23,7 +23,9 @@ public sealed class ApiKeyMiddleware(RequestDelegate next, ILogger<ApiKeyMiddlew
 
         var path = context.Request.Path.Value ?? string.Empty;
 
-        if (ExemptPaths.Any(p => path.Equals(p, StringComparison.OrdinalIgnoreCase)))
+        // Only require auth for /api/ paths; skip non-API requests (favicon.ico, etc.)
+        if (!path.StartsWith("/api/", StringComparison.OrdinalIgnoreCase) ||
+            ExemptPaths.Any(p => path.Equals(p, StringComparison.OrdinalIgnoreCase)))
         {
             await next(context);
             return;

--- a/src/HaPcRemote.Core/Services/SteamService.cs
+++ b/src/HaPcRemote.Core/Services/SteamService.cs
@@ -123,6 +123,7 @@ public class SteamService(ISteamPlatform platform) : ISteamService
 
         var appIdStr = data["appid"]?.ToString();
         var name = data["name"]?.ToString();
+        var lastPlayedStr = data["LastPlayed"]?.ToString();
         var lastUpdatedStr = data["LastUpdated"]?.ToString();
 
         if (string.IsNullOrEmpty(appIdStr) || string.IsNullOrEmpty(name))
@@ -131,9 +132,11 @@ public class SteamService(ISteamPlatform platform) : ISteamService
         if (!int.TryParse(appIdStr, out var appId))
             return null;
 
-        long.TryParse(lastUpdatedStr, out var lastUpdated);
+        // Prefer LastPlayed (actual play history); fall back to LastUpdated (install/update time)
+        if (!long.TryParse(lastPlayedStr, out var lastPlayed))
+            long.TryParse(lastUpdatedStr, out lastPlayed);
 
-        return new SteamGame { AppId = appId, Name = name, LastPlayed = lastUpdated };
+        return new SteamGame { AppId = appId, Name = name, LastPlayed = lastPlayed };
     }
 
     internal static string? ParseInstallDir(string acfContent)

--- a/tests/HaPcRemote.Service.Tests/Middleware/ApiKeyMiddlewareTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Middleware/ApiKeyMiddlewareTests.cs
@@ -159,6 +159,22 @@ public class ApiKeyMiddlewareTests
         called.ShouldBeTrue();
     }
 
+    [Theory]
+    [InlineData("/favicon.ico")]
+    [InlineData("/robots.txt")]
+    [InlineData("/")]
+    public async Task InvokeAsync_NonApiPath_SkipsAuth(string path)
+    {
+        var called = false;
+        var middleware = new ApiKeyMiddleware(_ => { called = true; return Task.CompletedTask; }, _logger);
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+
+        await middleware.InvokeAsync(context, CreateOptions());
+
+        called.ShouldBeTrue();
+    }
+
     [Fact]
     public async Task InvokeAsync_ValidKey_ResponseStatusRemainsDefault()
     {

--- a/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
@@ -46,7 +46,7 @@ public class SteamServiceTests
         game.ShouldNotBeNull();
         game.AppId.ShouldBe(730);
         game.Name.ShouldBe("Counter-Strike 2");
-        game.LastPlayed.ShouldBe(1700000000L);
+        game.LastPlayed.ShouldBe(1708000000L); // Uses LastPlayed field, not LastUpdated
     }
 
     [Fact]
@@ -371,6 +371,43 @@ public class SteamServiceTests
         game.ShouldNotBeNull();
         game.AppId.ShouldBe(0);
         game.Name.ShouldBe("Unknown App");
+    }
+
+    [Fact]
+    public void ParseAppManifest_OnlyLastUpdated_FallsBackToLastUpdated()
+    {
+        var acf = """
+            "AppState"
+            {
+                "appid"        "730"
+                "name"         "Counter-Strike 2"
+                "LastUpdated"  "1700000000"
+            }
+            """;
+
+        var game = SteamService.ParseAppManifest(acf);
+
+        game.ShouldNotBeNull();
+        game.LastPlayed.ShouldBe(1700000000L);
+    }
+
+    [Fact]
+    public void ParseAppManifest_BothFields_PrefersLastPlayed()
+    {
+        var acf = """
+            "AppState"
+            {
+                "appid"        "730"
+                "name"         "Counter-Strike 2"
+                "LastUpdated"  "1700000000"
+                "LastPlayed"   "1708000000"
+            }
+            """;
+
+        var game = SteamService.ParseAppManifest(acf);
+
+        game.ShouldNotBeNull();
+        game.LastPlayed.ShouldBe(1708000000L);
     }
 
     [Fact]

--- a/tests/HaPcRemote.Service.Tests/TestData/app-manifest-730.acf
+++ b/tests/HaPcRemote.Service.Tests/TestData/app-manifest-730.acf
@@ -5,4 +5,5 @@
     "StateFlags"    "4"
     "installdir"    "Counter-Strike Global Offensive"
     "LastUpdated"   "1700000000"
+    "LastPlayed"    "1708000000"
 }


### PR DESCRIPTION
## Summary
- **Favicon fix**: ApiKeyMiddleware now only requires auth for `/api/` paths — browser requests to `/favicon.ico` etc. no longer trigger API key warnings
- **Steam sorting fix**: `ParseAppManifest` reads `LastPlayed` field (actual play history) instead of `LastUpdated` (install/update time), with fallback for older manifests
- **README updates**: clarified entity turn_on/off script error (user script issue, not entity bug), marked image sizing resolved

## Test plan
- [x] 13 middleware tests pass (3 new: favicon.ico, robots.txt, root path)
- [x] 30 Steam service tests pass (2 new: LastPlayed preference, LastUpdated fallback)
- [x] Full suite: 201 tests pass