### PR TITLE
fix: Steam Big Picture works when Steam already running

### DIFF
--- a/src/HaPcRemote.Core/Services/SteamAppBootstrapper.cs
+++ b/src/HaPcRemote.Core/Services/SteamAppBootstrapper.cs
@@ -51,13 +51,13 @@ public static class SteamAppBootstrapper
             writer.SaveApp("steam-bigpicture", new AppDefinitionOptions
             {
                 DisplayName = "Steam Big Picture",
-                ExePath = exePath,
-                Arguments = "-bigpicture",
+                ExePath = "steam://open/bigpicture",
+                Arguments = null,
                 ProcessName = "steam",
-                UseShellExecute = false
+                UseShellExecute = true
             });
 
-            logger.LogInformation("Auto-registered Steam Big Picture app entry: {ExePath}", exePath);
+            logger.LogInformation("Auto-registered Steam Big Picture app entry via steam:// URI");
         }
     }
 }

--- a/tests/HaPcRemote.Service.Tests/Services/SteamAppBootstrapperTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/SteamAppBootstrapperTests.cs
@@ -48,10 +48,10 @@ public class SteamAppBootstrapperTests : IDisposable
             .MustHaveHappenedOnceExactly();
 
         A.CallTo(() => _writer.SaveApp("steam-bigpicture", A<AppDefinitionOptions>.That.Matches(a =>
-            a.ExePath == exePath &&
-            a.Arguments == "-bigpicture" &&
+            a.ExePath == "steam://open/bigpicture" &&
+            a.Arguments == null &&
             a.ProcessName == "steam" &&
-            a.UseShellExecute == false)))
+            a.UseShellExecute == true)))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -76,8 +76,9 @@ public class SteamAppBootstrapperTests : IDisposable
             .MustNotHaveHappened();
 
         A.CallTo(() => _writer.SaveApp("steam-bigpicture", A<AppDefinitionOptions>.That.Matches(a =>
-            a.ExePath == exePath &&
-            a.Arguments == "-bigpicture")))
+            a.ExePath == "steam://open/bigpicture" &&
+            a.Arguments == null &&
+            a.UseShellExecute == true)))
             .MustHaveHappenedOnceExactly();
     }
 


### PR DESCRIPTION
## Summary
- Uses `steam://open/bigpicture` URI instead of launching `steam.exe -bigpicture` directly
- Routes through the already-running Steam instance on subsequent invocations
- `UseShellExecute = true` lets Windows dispatch the `steam://` protocol handler

## Test plan
- [ ] Build passes
- [ ] Launch Big Picture when Steam is closed → works
- [ ] Launch Big Picture when Steam is already open → correctly opens Big Picture mode