### PR TITLE
feat: in-process Kestrel restart on port change

### DIFF
--- a/PLANNED_FEATURES.md
+++ b/PLANNED_FEATURES.md
@@ -43,8 +43,10 @@ Documented bugs that undermine trust in the integration.
   in right-aligned footer across all tabs (General, Games, Power, Log). PC Modes tab is
   the exception (has its own row management buttons). *(service)*
 
-- [ ] **General tab: Save + Restart → Apply with live reload** — No restart required.
-  Reload config and re-initialise Kestrel with new settings in-process. *(service)*
+- [x] **General tab: Save + Restart → Apply with live reload** — No restart required.
+  Kestrel stops, rebuilds on the new port, and restarts in-process. `KestrelRestartService`
+  singleton wires the delegate from Program.cs into DI so GeneralTab can call it directly.
+  No process relaunch, no UAC prompt. *(service)*
 
 
 - [x] **Steam: tray 503** — `POST /api/steam/run/{appId}` returns 200 even when the tray

--- a/src/HaPcRemote.Tray/KestrelRestartService.cs
+++ b/src/HaPcRemote.Tray/KestrelRestartService.cs
@@ -1,0 +1,15 @@
+namespace HaPcRemote.Tray;
+
+/// <summary>
+/// Singleton registered in the web app's DI container.
+/// Program.cs sets <see cref="RestartAsync"/> after the first WebApplication is built.
+/// GeneralTab resolves this service and calls RestartAsync to trigger an in-process Kestrel restart.
+/// </summary>
+internal sealed class KestrelRestartService
+{
+    /// <summary>
+    /// Set by Program.cs after the initial WebApplication is constructed.
+    /// Accepts the new port and performs stop + rebuild + start in-process.
+    /// </summary>
+    public Func<int, Task>? RestartAsync { get; set; }
+}

--- a/src/HaPcRemote.Tray/KestrelStatus.cs
+++ b/src/HaPcRemote.Tray/KestrelStatus.cs
@@ -2,7 +2,7 @@ namespace HaPcRemote.Tray;
 
 internal static class KestrelStatus
 {
-    private static readonly TaskCompletionSource _started = new();
+    private static TaskCompletionSource _started = new();
 
     public static bool IsRunning { get; private set; }
     public static string? Error { get; private set; }
@@ -16,7 +16,16 @@ internal static class KestrelStatus
 
     public static void SetFailed(string error)
     {
+        IsRunning = false;
         Error = error;
         _started.TrySetResult();
+    }
+
+    /// <summary>Reset status before an in-process restart so GeneralTab can await the new Started task.</summary>
+    public static void Reset()
+    {
+        IsRunning = false;
+        Error = null;
+        _started = new TaskCompletionSource();
     }
 }

--- a/src/HaPcRemote.Tray/TrayWebHost.cs
+++ b/src/HaPcRemote.Tray/TrayWebHost.cs
@@ -13,7 +13,7 @@ namespace HaPcRemote.Tray;
 
 internal static class TrayWebHost
 {
-    public static WebApplication Build(InMemoryLogProvider logProvider)
+    public static WebApplication Build(InMemoryLogProvider logProvider, KestrelRestartService? restartService = null)
     {
         var builder = WebApplication.CreateBuilder();
 
@@ -94,6 +94,12 @@ internal static class TrayWebHost
         builder.Services.AddSingleton<ISteamService, SteamService>();
         builder.Services.AddSingleton<IConfigurationWriter>(
             new ConfigurationWriter(writableConfigPath));
+
+        // KestrelRestartService is a singleton registered in DI so GeneralTab can resolve it.
+        // Program.cs sets the RestartAsync delegate on it after the first app is built.
+        // On subsequent builds (after a restart) the same instance is passed in so the delegate persists.
+        var restart = restartService ?? new KestrelRestartService();
+        builder.Services.AddSingleton(restart);
 
         var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- Replaces process restart with in-process Kestrel stop+rebuild+start on port change
- \`KestrelRestartService\` singleton registered in the web app's DI container; delegate wired by Program.cs after initial build
- GeneralTab calls \`RestartAsync()\` via the service instead of spawning a new process
- \`KestrelStatus.Reset()\` added to re-arm the started task between restarts
- Button label changed from "Save & Restart" to "Save & Apply"

## Test plan
- [ ] Build passes
- [ ] Change port in General tab → status shows "restarting..." then "listening" — no UAC/process dialog
- [ ] HA integration reconnects to new port after restart
- [ ] Cancelling the confirmation dialog leaves port unchanged
- [ ] If Kestrel fails to bind (port in use), status shows error and button re-enables