### PR TITLE
Fix ObjectDisposedException when opening settings from tray

### DIFF
--- a/src/HaPcRemote.Tray/Program.cs
+++ b/src/HaPcRemote.Tray/Program.cs
@@ -69,7 +69,7 @@ internal static class Program
             }
         });
 
-        Application.Run(new TrayApplicationContext(webApp.Services, webCts, logProvider));
+        Application.Run(new TrayApplicationContext(() => currentApp.Services, webCts, logProvider));
 
         webCts.Cancel();
         try { currentApp.StopAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult(); } catch { }

--- a/src/HaPcRemote.Tray/TrayApplicationContext.cs
+++ b/src/HaPcRemote.Tray/TrayApplicationContext.cs
@@ -28,7 +28,7 @@ internal sealed class TrayApplicationContext : ApplicationContext
     private readonly System.Windows.Forms.Timer _updateTimer;
     private readonly string _profilesPath;
     private readonly int _port;
-    private readonly IServiceProvider _webServices;
+    private readonly Func<IServiceProvider> _serviceAccessor;
     private readonly System.Windows.Forms.Timer _steamPollTimer;
     private readonly Icon _defaultIcon;
     private Icon? _playingIcon;
@@ -41,12 +41,13 @@ internal sealed class TrayApplicationContext : ApplicationContext
     private ToolStripMenuItem? _autoUpdateMenuItem;
     private UpdateChecker.ReleaseInfo? _pendingRelease;
 
-    public TrayApplicationContext(IServiceProvider webServices, CancellationTokenSource webCts, InMemoryLogProvider logProvider)
+    public TrayApplicationContext(Func<IServiceProvider> serviceAccessor, CancellationTokenSource webCts, InMemoryLogProvider logProvider)
     {
         _webCts = webCts;
         _logProvider = logProvider;
-        _webServices = webServices;
+        _serviceAccessor = serviceAccessor;
 
+        var webServices = serviceAccessor();
         var loggerFactory = webServices.GetRequiredService<ILoggerFactory>();
         _logger = loggerFactory.CreateLogger<TrayApplicationContext>();
 
@@ -120,18 +121,35 @@ internal sealed class TrayApplicationContext : ApplicationContext
     private void OnShowSettings(object? sender, EventArgs e)
     {
         EnsureSettingsForm();
-        _settingsForm!.ShowTab(0); // General tab
+        _settingsForm?.ShowTab(0); // General tab
     }
 
     private void OnShowLog(object? sender, EventArgs e)
     {
         EnsureSettingsForm();
-        _settingsForm!.ShowTab(4); // Log tab
+        _settingsForm?.ShowTab(4); // Log tab
     }
 
     private void EnsureSettingsForm()
     {
-        _settingsForm ??= new SettingsForm(_webServices, _logProvider);
+        if (_settingsForm is { IsDisposed: false })
+            return;
+
+        _settingsForm?.Dispose();
+
+        try
+        {
+            _settingsForm = new SettingsForm(_serviceAccessor(), _logProvider);
+        }
+        catch (ObjectDisposedException)
+        {
+            _settingsForm = null;
+            MessageBox.Show(
+                "The service is restarting. Please try again in a moment.",
+                "HA PC Remote",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
+        }
     }
 
     private void OnShowApiKey(object? sender, EventArgs e)
@@ -169,7 +187,7 @@ internal sealed class TrayApplicationContext : ApplicationContext
     {
         try
         {
-            var steamService = _webServices.GetRequiredService<ISteamService>();
+            var steamService = _serviceAccessor().GetRequiredService<ISteamService>();
             var running = await steamService.GetRunningGameAsync();
             var isPlaying = running != null;
             if (isPlaying == _isGamePlaying) return;


### PR DESCRIPTION
## Summary
- Replace direct `IServiceProvider` field in `TrayApplicationContext` with `Func<IServiceProvider>` that always resolves the current host's container
- `Program.cs` passes `() => currentApp.Services` so the tray automatically picks up the new provider after a Kestrel restart
- `EnsureSettingsForm` recreates the form when the previous instance was disposed, and shows a user-friendly message if the provider is mid-restart
- Steam poll timer also uses the accessor, avoiding silent `ObjectDisposedException` on that path

Closes #56

## Test plan
- [x] Start the service, open settings via tray double-click -- works normally
- [x] Trigger a reload via `POST /api/system/reload`, then open settings again -- no crash
- [ ] Verify steam poll continues working after a reload
- [x] Run `dotnet test` -- all 270 tests pass