### PR TITLE
fix: guarantee STA thread for WinForms tray UI

### DIFF
--- a/src/HaPcRemote.Tray/Program.cs
+++ b/src/HaPcRemote.Tray/Program.cs
@@ -6,6 +6,23 @@ internal static class Program
     [STAThread]
     private static void Main()
     {
+        // Microsoft.NET.Sdk.Web may override [STAThread]. If the current thread
+        // is not STA, re-launch on an explicit STA thread so WinForms, COM, OLE,
+        // clipboard, and drag-drop all work correctly.
+        if (Thread.CurrentThread.GetApartmentState() != ApartmentState.STA)
+        {
+            Thread staThread = new(RunApplication) { Name = "WinForms-STA" };
+            staThread.SetApartmentState(ApartmentState.STA);
+            staThread.Start();
+            staThread.Join();
+            return;
+        }
+
+        RunApplication();
+    }
+
+    private static void RunApplication()
+    {
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(false);
         Application.SetHighDpiMode(HighDpiMode.SystemAware);


### PR DESCRIPTION
## Summary
- `Microsoft.NET.Sdk.Web` can override `[STAThread]`, leaving the process in MTA mode
- COM/OLE calls throughout the tray UI then throw `ThreadStateException` (autocomplete dropdowns, clipboard, drag-drop, file dialogs)
- `Main()` now checks the apartment state at runtime; if not STA, it creates an explicit STA thread and runs `Application.Run()` there
- ASP.NET host continues on threadpool (MTA) threads as before — no change to Kestrel behaviour

Closes #48
Closes #51

## Test plan
- [ ] Launch tray app, verify no ThreadStateException in logs
- [ ] Open Settings > Games tab, click PC Mode dropdown in DataGridView — no crash
- [ ] Open Settings > PC Modes tab, verify autocomplete works on Launch/Kill App combos
- [ ] Verify Kestrel starts and responds to API requests
- [ ] Verify tray icon context menu and update check work