### PR TITLE
fix: remove misleading CI coverage bot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -47,18 +45,6 @@ jobs:
 
       - name: Write coverage to job summary
         run: cat coverage/report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
-
-      - name: Comment coverage on PR
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          recreate: true
-          path: coverage/report/SummaryGithub.md
-
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          files: coverage/report/Cobertura.xml
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Remove sticky PR comment (`marocchino/sticky-pull-request-comment`) and Codecov upload steps from build workflow
- Remove `pull-requests: write` permission that was only needed for the comment bot
- Root cause: test project references Core + Shared but not Service, so coverlet only instruments `HaPcRemote.Shared` (1 class, 15 lines) — same numbers on every PR
- Coverage job summary and artifact upload preserved for manual inspection

Closes #54

## Test plan
- [ ] CI build passes on this PR (no coverage comment should appear)
- [ ] Job summary still shows coverage markdown
- [ ] Coverage artifact still uploaded