### PR TITLE
Fix Linux publish build failure

### DIFF
--- a/src/HaPcRemote.Core/HaPcRemote.Core.csproj
+++ b/src/HaPcRemote.Core/HaPcRemote.Core.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ValveKeyValue" Version="0.20.0.417" />
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.3" />
-    <PackageReference Include="System.Management" Version="10.0.3" Condition="'$(RuntimeIdentifier)' == '' OR $([System.String]::Copy('%(RuntimeIdentifier)').StartsWith('win'))" />
+    <PackageReference Include="System.Management" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Remove broken conditional on `System.Management` package reference that used `%(RuntimeIdentifier)` (item metadata, always empty) instead of `$(RuntimeIdentifier)` (property)
- Package is now unconditional — compiles on all platforms, only used at runtime on Windows

## Test plan
- [x] `dotnet publish` for `linux-x64` succeeds locally
- [x] 292/292 tests pass
- [ ] CI build passes