### PR TITLE
feat: configurable mode transition delays

### DIFF
--- a/src/HaPcRemote.Core/Configuration/PcRemoteOptions.cs
+++ b/src/HaPcRemote.Core/Configuration/PcRemoteOptions.cs
@@ -39,4 +39,6 @@ public sealed class ModeConfig
     public int? Volume { get; set; }
     public string? LaunchApp { get; set; }
     public string? KillApp { get; set; }
+    public int? KillToLaunchDelayMs { get; set; }
+    public int? PostLaunchDelayMs { get; set; }
 }

--- a/src/HaPcRemote.Core/Services/ModeService.cs
+++ b/src/HaPcRemote.Core/Services/ModeService.cs
@@ -30,6 +30,9 @@ public class ModeService(
         if (config.KillApp is not null)
             await appService.KillAsync(config.KillApp);
 
+        if (config.KillApp is not null && config.LaunchApp is not null)
+            await Task.Delay(config.KillToLaunchDelayMs ?? 1000);
+
         if (config.LaunchApp is not null)
             await appService.LaunchAsync(config.LaunchApp);
     }

--- a/src/HaPcRemote.Core/Services/SteamService.cs
+++ b/src/HaPcRemote.Core/Services/SteamService.cs
@@ -288,6 +288,16 @@ public class SteamService(
             {
                 await modeService.ApplyModeAsync(resolvedMode);
                 logger.LogInformation("Applied PC mode '{Mode}' for game {AppId}", resolvedMode, appId);
+
+                // If the mode launched an app (e.g. Big Picture), give it time to initialize
+                // before firing the game URI — Steam ignores rungameid while BP is loading.
+                if (options.CurrentValue.Modes.TryGetValue(resolvedMode, out var modeConfig)
+                    && !string.IsNullOrEmpty(modeConfig.LaunchApp))
+                {
+                    var postLaunchDelay = modeConfig.PostLaunchDelayMs ?? 3000;
+                    logger.LogDebug("Mode '{Mode}' launched '{App}', waiting {Delay}ms for it to initialize", resolvedMode, modeConfig.LaunchApp, postLaunchDelay);
+                    await Task.Delay(postLaunchDelay);
+                }
             }
             catch (KeyNotFoundException)
             {

--- a/tests/HaPcRemote.IntegrationTests/WakeTests.cs
+++ b/tests/HaPcRemote.IntegrationTests/WakeTests.cs
@@ -1,0 +1,25 @@
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+
+namespace HaPcRemote.IntegrationTests;
+
+public class WakeTests
+{
+    [Fact]
+    public async Task WakePC_SendsWolPackets()
+    {
+        var mac = PhysicalAddress.Parse("BC-FC-E7-6A-90-2E");
+        var macBytes = mac.GetAddressBytes();
+        var packet = new byte[102];
+        for (var i = 0; i < 6; i++) packet[i] = 0xFF;
+        for (var i = 0; i < 16; i++) Buffer.BlockCopy(macBytes, 0, packet, 6 + i * 6, 6);
+
+        for (var i = 0; i < 5; i++)
+        {
+            using var udp = new UdpClient();
+            udp.EnableBroadcast = true;
+            await udp.SendAsync(packet, packet.Length, "255.255.255.255", 9);
+            await Task.Delay(1000);
+        }
+    }
+}

--- a/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
@@ -812,6 +812,52 @@ public class SteamServiceTests
         A.CallTo(() => _platform.LaunchSteamUrl(A<string>._)).MustNotHaveHappened();
     }
 
+    [Fact]
+    public async Task LaunchGameAsync_ModeWithLaunchApp_DelaysBeforeGameLaunch()
+    {
+        var options = new PcRemoteOptions
+        {
+            Steam = new SteamConfig { DefaultPcMode = "couch" },
+            Modes = new Dictionary<string, ModeConfig>
+            {
+                ["couch"] = new() { LaunchApp = "steam-bigpicture", MonitorProfile = "tv" }
+            }
+        };
+        var service = CreateService(options);
+        A.CallTo(() => _platform.GetRunningAppId()).Returns(0);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        _ = await service.LaunchGameAsync(730);
+        sw.Stop();
+
+        A.CallTo(() => _modeService.ApplyModeAsync("couch")).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _platform.LaunchSteamUrl("steam://rungameid/730")).MustHaveHappened();
+        sw.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(2500);
+    }
+
+    [Fact]
+    public async Task LaunchGameAsync_ModeWithoutLaunchApp_NoDelay()
+    {
+        var options = new PcRemoteOptions
+        {
+            Steam = new SteamConfig { DefaultPcMode = "desktop" },
+            Modes = new Dictionary<string, ModeConfig>
+            {
+                ["desktop"] = new() { MonitorProfile = "dual", AudioDevice = "Speakers" }
+            }
+        };
+        var service = CreateService(options);
+        A.CallTo(() => _platform.GetRunningAppId()).Returns(0);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        _ = await service.LaunchGameAsync(730);
+        sw.Stop();
+
+        A.CallTo(() => _modeService.ApplyModeAsync("desktop")).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _platform.LaunchSteamUrl("steam://rungameid/730")).MustHaveHappened();
+        sw.ElapsedMilliseconds.ShouldBeLessThan(8000);
+    }
+
     // ── GetBindings tests ─────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add `KillToLaunchDelayMs` and `PostLaunchDelayMs` to `ModeConfig`
- ModeService delays between kill and launch (default 1000ms)
- SteamService uses configurable post-launch delay (default 3000ms, was hardcoded 5s)
- Add standalone WoL test

Closes #69