### PR TITLE
Add prerelease toggle to auto-updater

### DIFF
--- a/src/HaPcRemote.Core/Services/UpdateService.cs
+++ b/src/HaPcRemote.Core/Services/UpdateService.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace HaPcRemote.Service.Services;
 
-public sealed class UpdateService(IHttpClientFactory httpClientFactory, ILogger<UpdateService> logger) : IUpdateService
+public sealed class UpdateService(IHttpClientFactory httpClientFactory, ILogger<UpdateService> logger, bool includePrereleases = false) : IUpdateService
 {
     private const string RepoOwner = "NeskireDK";
     private const string RepoName = "ha-pc-remote-service";
@@ -70,21 +70,50 @@ public sealed class UpdateService(IHttpClientFactory httpClientFactory, ILogger<
     private async Task<ReleaseInfo?> CheckForUpdateAsync(Version? currentVersion, CancellationToken ct)
     {
         using var client = CreateHttpClient();
-        var url = $"https://api.github.com/repos/{RepoOwner}/{RepoName}/releases/latest";
-        var release = await client.GetFromJsonAsync(url, UpdateJsonContext.Default.GitHubReleaseDto, ct);
-        if (release is null) return null;
 
-        var latestVersion = ParseVersion(release.TagName);
-        if (latestVersion is null || currentVersion is null || latestVersion <= currentVersion)
-            return null;
+        if (includePrereleases)
+        {
+            var url = $"https://api.github.com/repos/{RepoOwner}/{RepoName}/releases";
+            var releases = await client.GetFromJsonAsync(url, UpdateJsonContext.Default.ListGitHubReleaseDto, ct);
+            if (releases is null) return null;
+            return FindBestRelease(releases, currentVersion);
+        }
+        else
+        {
+            var url = $"https://api.github.com/repos/{RepoOwner}/{RepoName}/releases/latest";
+            var release = await client.GetFromJsonAsync(url, UpdateJsonContext.Default.GitHubReleaseDto, ct);
+            if (release is null) return null;
+            return FindBestRelease([release], currentVersion);
+        }
+    }
 
-        var installer = release.Assets?
-            .FirstOrDefault(a => a.Name.StartsWith(InstallerPrefix, StringComparison.OrdinalIgnoreCase)
-                              && a.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
-        if (installer is null) return null;
+    private ReleaseInfo? FindBestRelease(List<GitHubReleaseDto> releases, Version? currentVersion)
+    {
+        foreach (var release in releases)
+        {
+            if (!includePrereleases && IsPrerelease(release.TagName))
+                continue;
 
-        logger.LogInformation("Update available: {CurrentVersion} -> {LatestVersion}", currentVersion, release.TagName);
-        return new ReleaseInfo(release.TagName, installer.BrowserDownloadUrl);
+            var latestVersion = ParseVersion(release.TagName);
+            if (latestVersion is null || currentVersion is null || latestVersion <= currentVersion)
+                continue;
+
+            var installer = release.Assets?
+                .FirstOrDefault(a => a.Name.StartsWith(InstallerPrefix, StringComparison.OrdinalIgnoreCase)
+                                  && a.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
+            if (installer is null) continue;
+
+            logger.LogInformation("Update available: {CurrentVersion} -> {LatestVersion}", currentVersion, release.TagName);
+            return new ReleaseInfo(release.TagName, installer.BrowserDownloadUrl);
+        }
+
+        return null;
+    }
+
+    internal static bool IsPrerelease(string tagName)
+    {
+        var cleaned = tagName.TrimStart('v');
+        return cleaned.Contains('-');
     }
 
     private async Task<bool> DownloadAndInstallAsync(ReleaseInfo release, CancellationToken ct)
@@ -123,6 +152,9 @@ public sealed class UpdateService(IHttpClientFactory httpClientFactory, ILogger<
     private static Version? ParseVersion(string tag)
     {
         var cleaned = tag.TrimStart('v');
+        // Strip prerelease suffix (e.g. "1.7.0-rc.1" → "1.7.0")
+        var dashIdx = cleaned.IndexOf('-');
+        if (dashIdx >= 0) cleaned = cleaned[..dashIdx];
         if (!Version.TryParse(cleaned, out var v)) return null;
         return v.Build < 0 ? new Version(v.Major, v.Minor, 0) : v;
     }
@@ -158,4 +190,5 @@ internal sealed class GitHubAssetDto
 }
 
 [JsonSerializable(typeof(GitHubReleaseDto))]
+[JsonSerializable(typeof(List<GitHubReleaseDto>))]
 internal sealed partial class UpdateJsonContext : JsonSerializerContext;

--- a/src/HaPcRemote.Tray/Forms/GeneralTab.cs
+++ b/src/HaPcRemote.Tray/Forms/GeneralTab.cs
@@ -14,6 +14,7 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
     private readonly ToolTip _toolTip = new();
     private readonly ComboBox _logLevelCombo;
     private readonly CheckBox _autoUpdateCheck;
+    private readonly CheckBox _includePrereleasesCheck;
     private readonly NumericUpDown _portInput;
     private readonly Label _portStatusLabel;
     private readonly Button _portSaveButton;
@@ -148,15 +149,20 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
             AutoSize = true,
             Checked = settings.AutoUpdate
         };
-        _toolTip.SetToolTip(_autoUpdateCheck,
-            "Automatically download and install new service releases from GitHub.\n" +
-            "The tray icon will notify you before restarting.");
+        _includePrereleasesCheck = new CheckBox
+        {
+            Text = "Include Prereleases",
+            ForeColor = Color.White,
+            AutoSize = true,
+            Checked = settings.IncludePrereleases
+        };
 
         var autoUpdatePanel = new FlowLayoutPanel { FlowDirection = FlowDirection.LeftToRight, AutoSize = true };
         autoUpdatePanel.Controls.Add(_autoUpdateCheck);
+        autoUpdatePanel.Controls.Add(_includePrereleasesCheck);
         autoUpdatePanel.Controls.Add(MakeHelpIcon(_toolTip,
-            "Automatically download and install new service releases from GitHub.\n" +
-            "The tray icon will notify you before restarting."));
+            "Auto Update: Automatically download and install new service releases from GitHub.\n" +
+            "Include Prereleases: Also check for pre-release versions (e.g. v1.7.0-rc.1)."));
 
         layout.Controls.Add(new Label { AutoSize = true }, 0, row);
         layout.Controls.Add(autoUpdatePanel, 1, row++);
@@ -303,6 +309,7 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
         var s = TraySettings.Load();
         s.LogLevel = level;
         s.AutoUpdate = _autoUpdateCheck.Checked;
+        s.IncludePrereleases = _includePrereleasesCheck.Checked;
         s.Save();
     }
 
@@ -317,5 +324,6 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
             _ => "Warning"
         };
         _autoUpdateCheck.Checked = s.AutoUpdate;
+        _includePrereleasesCheck.Checked = s.IncludePrereleases;
     }
 }

--- a/src/HaPcRemote.Tray/Models/GitHubRelease.cs
+++ b/src/HaPcRemote.Tray/Models/GitHubRelease.cs
@@ -21,4 +21,5 @@ internal sealed class GitHubAsset
 }
 
 [JsonSerializable(typeof(GitHubRelease))]
+[JsonSerializable(typeof(List<GitHubRelease>))]
 internal partial class GitHubJsonContext : JsonSerializerContext;

--- a/src/HaPcRemote.Tray/Models/TraySettings.cs
+++ b/src/HaPcRemote.Tray/Models/TraySettings.cs
@@ -7,6 +7,7 @@ namespace HaPcRemote.Tray.Models;
 internal sealed class TraySettings
 {
     public bool AutoUpdate { get; set; } = false;
+    public bool IncludePrereleases { get; set; } = false;
     public string LogLevel { get; set; } = "Warning";
 
     public int SettingsWidth { get; set; }

--- a/src/HaPcRemote.Tray/Services/UpdateChecker.cs
+++ b/src/HaPcRemote.Tray/Services/UpdateChecker.cs
@@ -19,26 +19,26 @@ internal sealed class UpdateChecker(ILogger<UpdateChecker> logger)
     /// <summary>
     /// Checks GitHub for a newer release. Returns null if up-to-date or on error.
     /// </summary>
-    public async Task<ReleaseInfo?> CheckAsync(CancellationToken ct = default)
+    public async Task<ReleaseInfo?> CheckAsync(bool includePrereleases = false, CancellationToken ct = default)
     {
         try
         {
-            var url = $"https://api.github.com/repos/{RepoOwner}/{RepoName}/releases/latest";
-            var release = await Http.GetFromJsonAsync(url, GitHubJsonContext.Default.GitHubRelease, ct);
-            if (release is null) return null;
-
             var currentVersion = GetCurrentVersion();
-            var latestVersion = ParseVersion(release.TagName);
-            if (latestVersion is null || currentVersion is null || latestVersion <= currentVersion)
-                return null;
 
-            var installer = release.Assets?
-                .FirstOrDefault(a => a.Name.StartsWith(InstallerPrefix, StringComparison.OrdinalIgnoreCase)
-                                  && a.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
-            if (installer is null) return null;
-
-            logger.LogInformation("Update available: {CurrentVersion} -> {LatestVersion}", currentVersion, release.TagName);
-            return new ReleaseInfo(release.TagName, installer.BrowserDownloadUrl);
+            if (includePrereleases)
+            {
+                var url = $"https://api.github.com/repos/{RepoOwner}/{RepoName}/releases";
+                var releases = await Http.GetFromJsonAsync(url, GitHubJsonContext.Default.ListGitHubRelease, ct);
+                if (releases is null) return null;
+                return FindBestRelease(releases, currentVersion, includePrereleases);
+            }
+            else
+            {
+                var url = $"https://api.github.com/repos/{RepoOwner}/{RepoName}/releases/latest";
+                var release = await Http.GetFromJsonAsync(url, GitHubJsonContext.Default.GitHubRelease, ct);
+                if (release is null) return null;
+                return FindBestRelease([release], currentVersion, includePrereleases);
+            }
         }
         catch (HttpRequestException ex)
         {
@@ -50,6 +50,35 @@ internal sealed class UpdateChecker(ILogger<UpdateChecker> logger)
             logger.LogWarning(ex, "Update check failed");
             return null;
         }
+    }
+
+    internal ReleaseInfo? FindBestRelease(List<GitHubRelease> releases, Version? currentVersion, bool includePrereleases)
+    {
+        foreach (var release in releases)
+        {
+            if (!includePrereleases && IsPrerelease(release.TagName))
+                continue;
+
+            var latestVersion = ParseVersion(release.TagName);
+            if (latestVersion is null || currentVersion is null || latestVersion <= currentVersion)
+                continue;
+
+            var installer = release.Assets?
+                .FirstOrDefault(a => a.Name.StartsWith(InstallerPrefix, StringComparison.OrdinalIgnoreCase)
+                                  && a.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
+            if (installer is null) continue;
+
+            logger.LogInformation("Update available: {CurrentVersion} -> {LatestVersion}", currentVersion, release.TagName);
+            return new ReleaseInfo(release.TagName, installer.BrowserDownloadUrl);
+        }
+
+        return null;
+    }
+
+    internal static bool IsPrerelease(string tagName)
+    {
+        var cleaned = tagName.TrimStart('v');
+        return cleaned.Contains('-');
     }
 
     /// <summary>
@@ -113,6 +142,9 @@ internal sealed class UpdateChecker(ILogger<UpdateChecker> logger)
     private static Version? ParseVersion(string tag)
     {
         var cleaned = tag.TrimStart('v');
+        // Strip prerelease suffix (e.g. "1.7.0-rc.1" → "1.7.0")
+        var dashIdx = cleaned.IndexOf('-');
+        if (dashIdx >= 0) cleaned = cleaned[..dashIdx];
         if (!Version.TryParse(cleaned, out var v)) return null;
         // Normalize to 3-component so 0.7 == 0.7.0
         return v.Build < 0 ? new Version(v.Major, v.Minor, 0) : v;

--- a/src/HaPcRemote.Tray/TrayApplicationContext.cs
+++ b/src/HaPcRemote.Tray/TrayApplicationContext.cs
@@ -270,7 +270,8 @@ internal sealed class TrayApplicationContext : ApplicationContext
             _updateMenuItem.Text = "Checking...";
         }
 
-        var release = await _updateChecker.CheckAsync(_cts.Token);
+        var settings = TraySettings.Load();
+        var release = await _updateChecker.CheckAsync(settings.IncludePrereleases, _cts.Token);
 
         if (release is null)
         {

--- a/tests/HaPcRemote.Service.Tests/Services/UpdateServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/UpdateServiceTests.cs
@@ -38,6 +38,18 @@ public class UpdateServiceTests
 
     private static string MakeReleaseJson(string tagName, string? assetName = null, string? downloadUrl = null)
     {
+        var release = MakeReleaseObject(tagName, assetName, downloadUrl);
+        return JsonSerializer.Serialize(release);
+    }
+
+    private static string MakeReleasesJson(params (string tagName, string? assetName)[] releases)
+    {
+        var list = releases.Select(r => MakeReleaseObject(r.tagName, r.assetName)).ToArray();
+        return JsonSerializer.Serialize(list);
+    }
+
+    private static object MakeReleaseObject(string tagName, string? assetName = null, string? downloadUrl = null)
+    {
         var assets = new List<object>();
         if (assetName is not null)
         {
@@ -48,11 +60,7 @@ public class UpdateServiceTests
             });
         }
 
-        return JsonSerializer.Serialize(new
-        {
-            tag_name = tagName,
-            assets
-        });
+        return new { tag_name = tagName, assets };
     }
 
     // ── GetCurrentVersion ─────────────────────────────────────────────
@@ -332,6 +340,66 @@ public class UpdateServiceTests
         // The service catches generic exceptions, so it returns Failed
         var result = await task;
         result.Status.ShouldBe(UpdateStatus.Failed);
+    }
+
+    // ── IsPrerelease ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("v1.7.0-rc.1", true)]
+    [InlineData("v1.7.0-beta", true)]
+    [InlineData("v1.7.0-alpha.2", true)]
+    [InlineData("1.7.0-rc.1", true)]
+    [InlineData("v1.7.0", false)]
+    [InlineData("v1.7.0.0", false)]
+    [InlineData("1.7.0", false)]
+    public void IsPrerelease_DetectsHyphenInCleanedTag(string tag, bool expected)
+    {
+        UpdateService.IsPrerelease(tag).ShouldBe(expected);
+    }
+
+    // ── Prerelease filtering ─────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckAndApply_Default_UsesLatestEndpoint()
+    {
+        // Default (no prereleases) uses /releases/latest — single object response
+        var json = MakeReleaseJson("v0.0.1", "HaPcRemoteService-Setup-0.0.1.exe");
+        SetupHttpResponse(json);
+        var svc = CreateService();
+
+        var result = await svc.CheckAndApplyAsync();
+
+        result.Status.ShouldBe(UpdateStatus.UpToDate);
+    }
+
+    [Fact]
+    public async Task CheckAndApply_WithPrereleases_UsesReleasesEndpoint()
+    {
+        // With prereleases enabled, uses /releases — array response
+        var json = MakeReleasesJson(("v0.0.1-rc.1", "HaPcRemoteService-Setup-0.0.1-rc.1.exe"));
+        SetupHttpResponse(json);
+        var svc = new UpdateService(_httpClientFactory, _logger, includePrereleases: true);
+
+        var result = await svc.CheckAndApplyAsync();
+
+        // v0.0.1 <= current → UpToDate (but prerelease was NOT filtered out)
+        result.Status.ShouldBe(UpdateStatus.UpToDate);
+    }
+
+    [Fact]
+    public async Task CheckAndApply_WithPrereleases_SkipsStableFindsPrerelease()
+    {
+        // Prerelease v0.0.2-rc.1 comes after stable v0.0.1 — both pass through filter
+        var json = MakeReleasesJson(
+            ("v0.0.1", "HaPcRemoteService-Setup-0.0.1.exe"),
+            ("v0.0.2-rc.1", "HaPcRemoteService-Setup-0.0.2-rc.1.exe"));
+        SetupHttpResponse(json);
+        var svc = new UpdateService(_httpClientFactory, _logger, includePrereleases: true);
+
+        var result = await svc.CheckAndApplyAsync();
+
+        // Both <= current → UpToDate
+        result.Status.ShouldBe(UpdateStatus.UpToDate);
     }
 
     // ── Test helpers ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `IncludePrereleases` setting (default false) with checkbox in settings UI
- Default: uses `/releases/latest` (GitHub filters prereleases server-side)
- With flag: uses `/releases` and filters client-side by tag containing `-`
- Fixes `ParseVersion` to strip semver prerelease suffixes (`v1.7.0-rc.1` → `1.7.0`)
- 10 new tests (7 IsPrerelease + 3 filtering)

## Test plan
- [x] 434 unit tests pass
- [x] /simplify review — found and fixed ParseVersion bug for prerelease tags

Closes #81