### PR TITLE
G2: Tray bug fixes (B4, B5, B7)

### DIFF
--- a/src/HaPcRemote.Core/Services/HostLifetimeRestartService.cs
+++ b/src/HaPcRemote.Core/Services/HostLifetimeRestartService.cs
@@ -15,9 +15,12 @@ public sealed class HostLifetimeRestartService(
     {
         _ = Task.Run(async () =>
         {
-            await Task.Delay(500);
-            logger.LogInformation("Stopping host for restart");
-            lifetime.StopApplication();
-        });
+            await Task.Delay(500, lifetime.ApplicationStopping);
+            if (!lifetime.ApplicationStopping.IsCancellationRequested)
+            {
+                logger.LogInformation("Stopping host for restart");
+                lifetime.StopApplication();
+            }
+        }, lifetime.ApplicationStopping);
     }
 }

--- a/src/HaPcRemote.Core/Services/MdnsAdvertiserService.cs
+++ b/src/HaPcRemote.Core/Services/MdnsAdvertiserService.cs
@@ -23,7 +23,6 @@ public sealed class MdnsAdvertiserService(IOptionsMonitor<PcRemoteOptions> optio
     private static readonly IPAddress MdnsMulticastAddress = IPAddress.Parse("224.0.0.251");
     private static readonly IPEndPoint MdnsEndpoint = new(MdnsMulticastAddress, MdnsPort);
 
-    private readonly int _servicePort = options.CurrentValue.Port;
     private readonly string _hostname = GetHostname();
     private readonly string _instanceName = $"{Environment.MachineName}._pc-remote._tcp.local.";
     private readonly Dictionary<string, string> _txtRecords = new()
@@ -47,7 +46,7 @@ public sealed class MdnsAdvertiserService(IOptionsMonitor<PcRemoteOptions> optio
         {
             _udpClient = CreateUdpClient();
             _listenTask = ListenAsync(_cts.Token);
-            logger.LogInformation("mDNS advertiser started: {Instance} on port {Port}", _instanceName, _servicePort);
+            logger.LogInformation("mDNS advertiser started: {Instance} on port {Port}", _instanceName, options.CurrentValue.Port);
 
             // Send an initial unsolicited announcement
             _ = Task.Run(() => SendAnnouncementAsync(), cancellationToken);
@@ -255,7 +254,7 @@ public sealed class MdnsAdvertiserService(IOptionsMonitor<PcRemoteOptions> optio
         WriteBigEndian(writer, (ushort)(6 + srvTarget.Length));
         WriteBigEndian(writer, 0); // Priority
         WriteBigEndian(writer, 0); // Weight
-        WriteBigEndian(writer, (ushort)_servicePort); // Port
+        WriteBigEndian(writer, (ushort)options.CurrentValue.Port); // Port
         writer.Write(srvTarget);
 
         // TXT record

--- a/src/HaPcRemote.Core/Services/SteamService.cs
+++ b/src/HaPcRemote.Core/Services/SteamService.cs
@@ -149,6 +149,8 @@ public sealed class SteamService(
         // If Steam reports a non-zero, non-shortcut appId, use that instead
         if (steamAppId != 0 && !IsShortcutAppId(steamAppId))
         {
+            if (result != null)
+                logger.LogDebug("Overriding shortcut diagnostic result with standard game {AppId}", steamAppId);
             var name = _cachedGames?.Find(g => g.AppId == steamAppId)?.Name ?? $"Unknown ({steamAppId})";
             result = new SteamRunningGame { AppId = steamAppId, Name = name };
         }

--- a/src/HaPcRemote.Core/Services/WindowsIdleService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsIdleService.cs
@@ -75,13 +75,13 @@ public sealed partial class WindowsIdleService : IIdleService
         if (!GetLastInputInfo(ref info))
             return null;
 
-        var kbMouseIdleMs = (uint)Environment.TickCount - info.dwTime;
+        var kbMouseIdleMs = (ulong)Environment.TickCount64 - info.dwTime;
 
         // Gamepad idle — poll all 4 XInput slots
         PollGamepads();
-        var gamepadIdleMs = Environment.TickCount64 - LastGamepadInputTick;
+        var gamepadIdleMs = (ulong)(Environment.TickCount64 - LastGamepadInputTick);
 
-        var minIdleMs = Math.Min(kbMouseIdleMs, (uint)Math.Min(gamepadIdleMs, uint.MaxValue));
+        var minIdleMs = Math.Min(kbMouseIdleMs, gamepadIdleMs);
         return (int)(minIdleMs / 1000);
     }
 

--- a/src/HaPcRemote.Tray/KestrelStatus.cs
+++ b/src/HaPcRemote.Tray/KestrelStatus.cs
@@ -2,6 +2,7 @@ namespace HaPcRemote.Tray;
 
 internal static class KestrelStatus
 {
+    private static readonly object _sync = new();
     private static TaskCompletionSource _started = new();
 
     public static bool IsRunning { get; private set; }
@@ -10,22 +11,31 @@ internal static class KestrelStatus
 
     public static void SetRunning()
     {
-        IsRunning = true;
+        lock (_sync)
+        {
+            IsRunning = true;
+        }
         _started.TrySetResult();
     }
 
     public static void SetFailed(string error)
     {
-        IsRunning = false;
-        Error = error;
+        lock (_sync)
+        {
+            IsRunning = false;
+            Error = error;
+        }
         _started.TrySetResult();
     }
 
     /// <summary>Reset status before an in-process restart so GeneralTab can await the new Started task.</summary>
     public static void Reset()
     {
-        IsRunning = false;
-        Error = null;
-        _started = new TaskCompletionSource();
+        lock (_sync)
+        {
+            IsRunning = false;
+            Error = null;
+        }
+        Interlocked.Exchange(ref _started, new TaskCompletionSource());
     }
 }

--- a/src/HaPcRemote.Tray/Program.cs
+++ b/src/HaPcRemote.Tray/Program.cs
@@ -3,6 +3,9 @@ using HaPcRemote.Tray.Logging;
 
 internal static class Program
 {
+    // Volatile so the STA thread and the Task.Run restart lambda always see the latest reference.
+    private static volatile WebApplication? _currentApp;
+
     [STAThread]
     private static void Main()
     {
@@ -43,7 +46,7 @@ internal static class Program
         var restartService = webApp.Services.GetRequiredService<KestrelRestartService>();
 
         // Active web application reference — swapped on each restart.
-        WebApplication currentApp = webApp;
+        _currentApp = webApp;
         var restartLock = new SemaphoreSlim(1, 1);
 
         restartService.RestartAsync = async newPort =>
@@ -53,11 +56,12 @@ internal static class Program
             {
                 KestrelStatus.Reset();
 
-                await currentApp.StopAsync(TimeSpan.FromSeconds(5));
-                await currentApp.DisposeAsync();
+                var oldApp = _currentApp!;
+                await oldApp.StopAsync(TimeSpan.FromSeconds(5));
+                await oldApp.DisposeAsync();
 
                 var newApp = TrayWebHost.Build(logProvider, restartService);
-                currentApp = newApp;
+                _currentApp = newApp;
 
                 await newApp.StartAsync();
                 KestrelStatus.SetRunning();
@@ -86,9 +90,9 @@ internal static class Program
             }
         });
 
-        Application.Run(new TrayApplicationContext(() => currentApp.Services, webCts, logProvider));
+        Application.Run(new TrayApplicationContext(() => _currentApp!.Services, webCts, logProvider));
 
         webCts.Cancel();
-        try { currentApp.StopAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult(); } catch { }
+        try { _currentApp?.StopAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult(); } catch { }
     }
 }

--- a/src/HaPcRemote.Tray/TrayApplicationContext.cs
+++ b/src/HaPcRemote.Tray/TrayApplicationContext.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using HaPcRemote.Service.Logging;
 using HaPcRemote.Service.Services;
 using HaPcRemote.Service.Configuration;
@@ -31,7 +32,11 @@ internal sealed class TrayApplicationContext : ApplicationContext
     private readonly System.Windows.Forms.Timer _steamPollTimer;
     private readonly Icon _defaultIcon;
     private Icon? _playingIcon;
+    private IntPtr _playingIconHandle;
     private bool _isGamePlaying;
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool DestroyIcon(IntPtr hIcon);
 
     private readonly SemaphoreSlim _updateLock = new(1, 1);
 
@@ -193,8 +198,16 @@ internal sealed class TrayApplicationContext : ApplicationContext
         using var g = Graphics.FromImage(bmp);
         using var brush = new SolidBrush(Color.Lime);
         g.FillEllipse(brush, bmp.Width - 7, bmp.Height - 7, 6, 6);
-        _playingIcon = Icon.FromHandle(bmp.GetHicon());
+        var hIcon = bmp.GetHicon();
         bmp.Dispose();
+        var newIcon = Icon.FromHandle(hIcon);
+        if (_playingIconHandle != IntPtr.Zero)
+        {
+            _playingIcon?.Dispose();
+            DestroyIcon(_playingIconHandle);
+        }
+        _playingIconHandle = hIcon;
+        _playingIcon = newIcon;
         return _playingIcon;
     }
 
@@ -354,6 +367,8 @@ internal sealed class TrayApplicationContext : ApplicationContext
             _updateTimer.Dispose();
             _steamPollTimer.Dispose();
             _playingIcon?.Dispose();
+            if (_playingIconHandle != IntPtr.Zero)
+                DestroyIcon(_playingIconHandle);
             _settingsForm?.Dispose();
             _notifyIcon.Visible = false;
             _notifyIcon.Dispose();


### PR DESCRIPTION
## Summary
- B4: Synchronise KestrelStatus static state with lock/Interlocked
- B5: Destroy HICON handle to prevent GDI leak in tray icon
- B7: Eliminate currentApp closure race with volatile field