### PR TITLE
G3: Endpoint/middleware fixes (B8, B9, B10, D6)

### DIFF
--- a/src/HaPcRemote.Core/Endpoints/ArtworkDebugEndpoints.cs
+++ b/src/HaPcRemote.Core/Endpoints/ArtworkDebugEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using HaPcRemote.Service.Middleware;
 using HaPcRemote.Service.Models;
 using HaPcRemote.Service.Services;
 using HaPcRemote.Service.Views;
@@ -10,7 +11,10 @@ public static class ArtworkDebugEndpoints
 {
     public static IEndpointRouteBuilder MapArtworkDebugEndpoints(this IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGet("/api/steam/artwork/debug", async (HttpContext context, ISteamService steamService) =>
+        var group = endpoints.MapGroup("/");
+        group.AddEndpointFilter<EndpointExceptionFilter>();
+
+        group.MapGet("/api/steam/artwork/debug", async (HttpContext context, ISteamService steamService) =>
         {
             var remote = context.Connection.RemoteIpAddress;
             if (remote is not null && !IPAddress.IsLoopback(remote))
@@ -21,7 +25,7 @@ public static class ArtworkDebugEndpoints
             return Results.Content(html, "text/html");
         });
 
-        endpoints.MapGet("/api/steam/artwork/{appId:int}/debug", async (int appId, HttpContext context, ISteamService steamService) =>
+        group.MapGet("/api/steam/artwork/{appId:int}/debug", async (int appId, HttpContext context, ISteamService steamService) =>
         {
             var remote = context.Connection.RemoteIpAddress;
             if (remote is not null && !IPAddress.IsLoopback(remote))
@@ -35,7 +39,7 @@ public static class ArtworkDebugEndpoints
             return Results.Content(html, "text/html");
         });
 
-        endpoints.MapGet("/api/debug/styles.css", (HttpContext context) =>
+        group.MapGet("/api/debug/styles.css", (HttpContext context) =>
         {
             var remote = context.Connection.RemoteIpAddress;
             if (remote is not null && !IPAddress.IsLoopback(remote))

--- a/src/HaPcRemote.Core/Endpoints/DebugEndpoints.cs
+++ b/src/HaPcRemote.Core/Endpoints/DebugEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using HaPcRemote.Service.Configuration;
+using HaPcRemote.Service.Middleware;
 using HaPcRemote.Service.Views;
 using HaPcRemote.Shared.Configuration;
 using Microsoft.Extensions.Options;
@@ -14,7 +15,10 @@ public static class DebugEndpoints
 
     public static IEndpointRouteBuilder MapDebugEndpoints(this IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGet("/api-explorer", (HttpContext context, IOptionsMonitor<PcRemoteOptions> options) =>
+        var group = endpoints.MapGroup("/");
+        group.AddEndpointFilter<EndpointExceptionFilter>();
+
+        group.MapGet("/api-explorer", (HttpContext context, IOptionsMonitor<PcRemoteOptions> options) =>
         {
             var remote = context.Connection.RemoteIpAddress;
             if (remote is not null && !IPAddress.IsLoopback(remote))
@@ -25,7 +29,7 @@ public static class DebugEndpoints
             return Results.Content(html, "text/html");
         });
 
-        endpoints.MapGet("/api/debug/logs", (HttpContext context, int? lines, string? level, string? category) =>
+        group.MapGet("/api/debug/logs", (HttpContext context, int? lines, string? level, string? category) =>
         {
             var remote = context.Connection.RemoteIpAddress;
             if (remote is not null && !IPAddress.IsLoopback(remote))

--- a/src/HaPcRemote.Core/Endpoints/HealthEndpoints.cs
+++ b/src/HaPcRemote.Core/Endpoints/HealthEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Reflection;
+using HaPcRemote.Service.Middleware;
 using HaPcRemote.Service.Models;
 
 namespace HaPcRemote.Service.Endpoints;
@@ -10,6 +11,7 @@ public static class HealthEndpoints
     public static RouteGroupBuilder MapHealthEndpoints(this IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("/api");
+        group.AddEndpointFilter<EndpointExceptionFilter>();
 
         group.MapGet("/health", () =>
         {

--- a/src/HaPcRemote.Core/Endpoints/SystemStateEndpoints.cs
+++ b/src/HaPcRemote.Core/Endpoints/SystemStateEndpoints.cs
@@ -1,4 +1,5 @@
 using HaPcRemote.Service.Configuration;
+using HaPcRemote.Service.Middleware;
 using HaPcRemote.Service.Models;
 using HaPcRemote.Service.Services;
 using Microsoft.Extensions.Options;
@@ -9,7 +10,10 @@ public static class SystemStateEndpoints
 {
     public static IEndpointRouteBuilder MapSystemStateEndpoints(this IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGet("/api/system/state", async (
+        var group = endpoints.MapGroup("/api/system");
+        group.AddEndpointFilter<EndpointExceptionFilter>();
+
+        group.MapGet("/state", async (
             IAudioService audioService,
             IMonitorService monitorService,
             ISteamService steamService,

--- a/src/HaPcRemote.Core/Middleware/ApiKeyMiddleware.cs
+++ b/src/HaPcRemote.Core/Middleware/ApiKeyMiddleware.cs
@@ -9,7 +9,7 @@ public sealed class ApiKeyMiddleware(RequestDelegate next, ILogger<ApiKeyMiddlew
 {
     private const string ApiKeyHeaderName = "X-Api-Key";
 
-    private static readonly string[] ExemptPaths = ["/api/health", "/api/steam/artwork"];
+    private static readonly string[] ExemptPaths = ["/api/health"];
 
     public async Task InvokeAsync(HttpContext context, IOptionsMonitor<PcRemoteOptions> options)
     {
@@ -23,8 +23,14 @@ public sealed class ApiKeyMiddleware(RequestDelegate next, ILogger<ApiKeyMiddlew
 
         var path = context.Request.Path.Value ?? string.Empty;
 
+        // Artwork image requests are exempt so HA can fetch art without auth.
+        // Diagnostics endpoints under /api/steam/artwork/ are NOT exempt.
+        var isArtworkImageRequest = path.StartsWith("/api/steam/artwork/", StringComparison.OrdinalIgnoreCase)
+            && !path.EndsWith("/diagnostics", StringComparison.OrdinalIgnoreCase);
+
         // Only require auth for /api/ paths; skip non-API requests (favicon.ico, etc.)
         if (!path.StartsWith("/api/", StringComparison.OrdinalIgnoreCase) ||
+            isArtworkImageRequest ||
             ExemptPaths.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
         {
             await next(context);

--- a/src/HaPcRemote.Core/Views/EmbeddedResourceHelper.cs
+++ b/src/HaPcRemote.Core/Views/EmbeddedResourceHelper.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text;
 
@@ -6,7 +7,7 @@ namespace HaPcRemote.Service.Views;
 public static class EmbeddedResourceHelper
 {
     private static readonly Assembly CurrentAssembly = typeof(EmbeddedResourceHelper).Assembly;
-    private static readonly Dictionary<string, string> ResourceCache = new();
+    private static readonly ConcurrentDictionary<string, string> ResourceCache = new();
 
     /// <summary>
     /// Loads an embedded resource file from the Views folder.
@@ -18,17 +19,15 @@ public static class EmbeddedResourceHelper
     {
         var cacheKey = $"Views/{fileName}";
 
-        if (ResourceCache.TryGetValue(cacheKey, out var cached))
-            return cached;
+        return ResourceCache.GetOrAdd(cacheKey, _ =>
+        {
+            var resourceName = $"HaPcRemote.Service.Views.{fileName}";
+            using var stream = CurrentAssembly.GetManifestResourceStream(resourceName)
+                ?? throw new FileNotFoundException($"Embedded resource not found: {resourceName}");
 
-        var resourceName = $"HaPcRemote.Service.Views.{fileName}";
-        using var stream = CurrentAssembly.GetManifestResourceStream(resourceName)
-            ?? throw new FileNotFoundException($"Embedded resource not found: {resourceName}");
-
-        using var reader = new StreamReader(stream, Encoding.UTF8);
-        var content = reader.ReadToEnd();
-        ResourceCache[cacheKey] = content;
-        return content;
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            return reader.ReadToEnd();
+        });
     }
 
     /// <summary>

--- a/src/HaPcRemote.Headless/Program.cs
+++ b/src/HaPcRemote.Headless/Program.cs
@@ -86,5 +86,8 @@ app.MapAudioEndpoints();
 app.MapMonitorEndpoints();
 app.MapSteamEndpoints();
 app.MapArtworkDebugEndpoints();
+// MapPowerEndpoints() is intentionally omitted: the headless host does not register
+// IConfigurationWriter, so the PUT /api/system/power endpoint would fail at runtime.
+// Power config writes are only supported via the Tray host (Windows).
 
 await app.RunAsync();


### PR DESCRIPTION
## Summary
- B8: Narrow artwork auth bypass to exclude diagnostics endpoints
- B9: Add EndpointExceptionFilter to 4 endpoint classes missing it
- B10: Use ConcurrentDictionary in EmbeddedResourceHelper to prevent race
- D6: Document MapPowerEndpoints omission in Headless host (IConfigurationWriter not registered)

## Test plan
- [ ] All existing unit tests pass (pre-existing failure in LinuxMonitorServiceTests.EnableMonitorAsync_CallsXrandrAuto exists on base branch)
- [ ] Auth bypass correctly allows artwork image requests but blocks diagnostics