### PR TITLE
G8: C# test quality (T1, T2, T5, T6, T7, T14, T16, T19, T20)

### DIFF
--- a/src/HaPcRemote.Core/Services/SteamService.cs
+++ b/src/HaPcRemote.Core/Services/SteamService.cs
@@ -12,8 +12,10 @@ public class SteamService(
     IOptionsMonitor<PcRemoteOptions> options,
     IHttpClientFactory httpClientFactory,
     IEmulatorTracker emulatorTracker,
-    ILogger<SteamService> logger) : ISteamService
+    ILogger<SteamService> logger,
+    Func<int, Task>? delay = null) : ISteamService
 {
+    private readonly Func<int, Task> _delay = delay ?? (ms => Task.Delay(ms));
     private List<SteamGame>? _cachedGames;
     private DateTime _cacheExpiry;
     private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
@@ -296,7 +298,7 @@ public class SteamService(
                 {
                     var postLaunchDelay = modeConfig.PostLaunchDelayMs ?? 3000;
                     logger.LogDebug("Mode '{Mode}' launched '{App}', waiting {Delay}ms for it to initialize", resolvedMode, modeConfig.LaunchApp, postLaunchDelay);
-                    await Task.Delay(postLaunchDelay);
+                    await _delay(postLaunchDelay);
                 }
             }
             catch (KeyNotFoundException)

--- a/src/HaPcRemote.Core/Services/SteamService.cs
+++ b/src/HaPcRemote.Core/Services/SteamService.cs
@@ -444,6 +444,15 @@ public class SteamService(
     public bool IsSteamRunning() => platform.IsSteamRunning();
 
     /// <summary>
+    /// Seeds the game cache directly. Intended for test use only.
+    /// </summary>
+    internal void SetCachedGamesForTest(List<SteamGame> games)
+    {
+        _cachedGames = games;
+        _cacheExpiry = DateTime.UtcNow + CacheDuration;
+    }
+
+    /// <summary>
     /// Resolve which PC mode to apply for a given game.
     /// Per-game binding takes priority, then default, then none.
     /// Returns null/empty if no mode switch should happen.

--- a/tests/HaPcRemote.IntegrationTests/HealthEndpointTests.cs
+++ b/tests/HaPcRemote.IntegrationTests/HealthEndpointTests.cs
@@ -15,6 +15,7 @@ public class HealthEndpointTests : IntegrationTestBase
         response.Success.ShouldBeTrue();
         response.Data.ShouldNotBeNull();
         response.Data.MachineName.ShouldNotBeNullOrWhiteSpace();
+        response.Data.Version.ShouldNotBeNullOrEmpty();
         response.Data.MacAddresses.ShouldNotBeNull();
         response.Data.MacAddresses.ShouldNotBeEmpty();
     }

--- a/tests/HaPcRemote.IntegrationTests/Models/HealthResponse.cs
+++ b/tests/HaPcRemote.IntegrationTests/Models/HealthResponse.cs
@@ -4,6 +4,7 @@ public class HealthResponse
 {
     public string Status { get; set; } = string.Empty;
     public string? MachineName { get; set; }
+    public string? Version { get; set; }
     public List<MacAddressInfo>? MacAddresses { get; set; }
 }
 

--- a/tests/HaPcRemote.Service.Tests/Endpoints/MonitorEndpointTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Endpoints/MonitorEndpointTests.cs
@@ -62,4 +62,49 @@ public class MonitorEndpointTests : EndpointTestBase
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
 
+    [Fact]
+    public async Task DisableMonitor_ValidId_Returns200()
+    {
+        A.CallTo(() => MonitorService.DisableMonitorAsync("DEL4321")).Returns(Task.CompletedTask);
+        using var client = CreateClient();
+
+        var response = await client.PostAsync("/api/monitor/disable/DEL4321", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task DisableMonitor_InvalidId_Returns404()
+    {
+        A.CallTo(() => MonitorService.DisableMonitorAsync("UNKNOWN"))
+            .Throws(new KeyNotFoundException("Monitor 'UNKNOWN' not found."));
+        using var client = CreateClient();
+
+        var response = await client.PostAsync("/api/monitor/disable/UNKNOWN", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task SoloMonitor_ValidId_Returns200()
+    {
+        A.CallTo(() => MonitorService.SoloMonitorAsync("GSM59A4")).Returns(Task.CompletedTask);
+        using var client = CreateClient();
+
+        var response = await client.PostAsync("/api/monitor/solo/GSM59A4", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task SetPrimaryMonitor_ValidId_Returns200()
+    {
+        A.CallTo(() => MonitorService.SetPrimaryAsync("GSM59A4")).Returns(Task.CompletedTask);
+        using var client = CreateClient();
+
+        var response = await client.PostAsync("/api/monitor/primary/GSM59A4", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
 }

--- a/tests/HaPcRemote.Service.Tests/Endpoints/SteamEndpointTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Endpoints/SteamEndpointTests.cs
@@ -87,4 +87,37 @@ public class SteamEndpointTests : EndpointTestBase
         json.ShouldNotBeNull();
         json.Success.ShouldBeTrue();
     }
+
+    [Fact]
+    public async Task GetGames_SteamInstalled_ReturnsGameList()
+    {
+        // Non-existent path → empty list (no manifests), but does not throw
+        A.CallTo(() => SteamPlatform.GetSteamPath()).Returns("C:\\FakeNonExistentSteamPath_12345");
+        using var client = CreateClient();
+
+        var response = await client.GetAsync("/api/steam/games");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var json = await response.Content.ReadFromJsonAsync<ApiResponse<List<SteamGame>>>(
+            AppJsonContext.Default.ApiResponseListSteamGame);
+        json.ShouldNotBeNull();
+        json.Success.ShouldBeTrue();
+        json.Data.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Stop_GameRunning_StopsGame_Returns200()
+    {
+        A.CallTo(() => SteamPlatform.GetRunningAppId()).Returns(730);
+        A.CallTo(() => SteamPlatform.GetSteamPath()).Returns("C:\\FakeNonExistentSteamPath_12345");
+        using var client = CreateClient();
+
+        var response = await client.PostAsync("/api/steam/stop", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var json = await response.Content.ReadFromJsonAsync<ApiResponse>(
+            AppJsonContext.Default.ApiResponse);
+        json.ShouldNotBeNull();
+        json.Success.ShouldBeTrue();
+    }
 }

--- a/tests/HaPcRemote.Service.Tests/Services/LinuxIdleServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/LinuxIdleServiceTests.cs
@@ -20,20 +20,6 @@ public class LinuxIdleServiceTests
         result.ShouldBeNull();
     }
 
-    [Fact]
-    public void GetIdleSeconds_CachesBackendDetection()
-    {
-        var service = new LinuxIdleService(_logger);
-
-        // Call twice — backend detection runs only once
-        service.GetIdleSeconds();
-        service.GetIdleSeconds();
-
-        // If backend detection ran twice, we'd see two log messages.
-        // The "none" backend log only fires once.
-        // We can't easily assert on this without more infrastructure,
-        // but at least verify it doesn't throw.
-    }
 }
 
 public class MutterIdleBackendParsingTests

--- a/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
@@ -459,14 +459,13 @@ public class SteamServiceTests
     }
 
     [Fact]
-    public async Task GetGamesAsync_EmptySteamPath_Throws()
+    public async Task GetGamesAsync_NonExistentPath_ReturnsEmpty()
     {
-        A.CallTo(() => _platform.GetSteamPath()).Returns(string.Empty);
+        // GetSteamPath returns a non-null but non-existent path — libraryfolders.vdf won't exist
+        // so LoadInstalledGames returns empty list without throwing
+        A.CallTo(() => _platform.GetSteamPath()).Returns("C:\\FakeNonExistentSteamPath_12345");
         var service = CreateService();
 
-        // GetSteamPath returns empty string — treated as non-null but libraryfolders.vdf won't exist
-        // so should return empty list, not throw
-        A.CallTo(() => _platform.GetSteamPath()).Returns("C:\\FakeNonExistentSteamPath_12345");
         var result = await service.GetGamesAsync();
 
         result.ShouldBeEmpty();

--- a/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
@@ -175,15 +175,24 @@ public class SteamServiceTests
     public async Task GetRunningGame_GameRunning_CacheWarm_ReturnsGameInfo()
     {
         A.CallTo(() => _platform.GetRunningAppId()).Returns(730);
-        A.CallTo(() => _platform.GetSteamPath()).Returns(@"C:\Steam");
+        A.CallTo(() => _platform.GetSteamPath()).Returns(@"C:\FakeNonExistentSteamPath_12345");
         var service = CreateService();
-        // Warm the cache manually via GetGamesAsync (returns empty list since filesystem is fake)
-        // Then set up the cache via reflection would be complex — instead just verify the result
-        // with an empty cache: name falls back to "Unknown (730)" but appId is correct
+
+        // Pre-warm the cache with a non-empty game list so the warm-path check (_cachedGames.Count == 0) doesn't re-trigger
+        await service.GetGamesAsync();
+        InjectCachedGames(service, [new SteamGame { AppId = 730, Name = "Counter-Strike 2", LastPlayed = 0 }]);
+
+        // Reset call count tracking so we can assert the warm path doesn't reload
+        Fake.ClearRecordedCalls(_platform);
+        A.CallTo(() => _platform.GetRunningAppId()).Returns(730);
+
         var result = await service.GetRunningGameAsync();
 
         result.ShouldNotBeNull();
         result.AppId.ShouldBe(730);
+        result.Name.ShouldBe("Counter-Strike 2");
+        // Cache was warm — GetSteamPath must not have been called to reload games
+        A.CallTo(() => _platform.GetSteamPath()).MustNotHaveHappened();
     }
 
     [Fact]

--- a/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
@@ -18,12 +18,12 @@ public class SteamServiceTests
     private readonly IHttpClientFactory _httpClientFactory = A.Fake<IHttpClientFactory>();
     private readonly IEmulatorTracker _emulatorTracker = A.Fake<IEmulatorTracker>();
 
-    private SteamService CreateService(PcRemoteOptions? options = null)
+    private SteamService CreateService(PcRemoteOptions? options = null, Func<int, Task>? delay = null)
     {
         options ??= new PcRemoteOptions();
         var monitor = A.Fake<IOptionsMonitor<PcRemoteOptions>>();
         A.CallTo(() => monitor.CurrentValue).Returns(options);
-        return new SteamService(_platform, _modeService, monitor, _httpClientFactory, _emulatorTracker, _logger);
+        return new SteamService(_platform, _modeService, monitor, _httpClientFactory, _emulatorTracker, _logger, delay);
     }
 
     // ── ParseLibraryFolders tests (static) ───────────────────────────
@@ -823,16 +823,15 @@ public class SteamServiceTests
                 ["couch"] = new() { LaunchApp = "steam-bigpicture", SoloMonitor = "tv" }
             }
         };
-        var service = CreateService(options);
+        var delayMs = new List<int>();
+        var service = CreateService(options, delay: ms => { delayMs.Add(ms); return Task.CompletedTask; });
         A.CallTo(() => _platform.GetRunningAppId()).Returns(0);
 
-        var sw = System.Diagnostics.Stopwatch.StartNew();
         _ = await service.LaunchGameAsync(730);
-        sw.Stop();
 
         A.CallTo(() => _modeService.ApplyModeAsync("couch")).MustHaveHappenedOnceExactly();
         A.CallTo(() => _platform.LaunchSteamUrl("steam://rungameid/730")).MustHaveHappened();
-        sw.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(2500);
+        delayMs.ShouldContain(3000); // default PostLaunchDelayMs
     }
 
     [Fact]
@@ -846,16 +845,15 @@ public class SteamServiceTests
                 ["desktop"] = new() { SoloMonitor = "dual", AudioDevice = "Speakers" }
             }
         };
-        var service = CreateService(options);
+        var delayMs = new List<int>();
+        var service = CreateService(options, delay: ms => { delayMs.Add(ms); return Task.CompletedTask; });
         A.CallTo(() => _platform.GetRunningAppId()).Returns(0);
 
-        var sw = System.Diagnostics.Stopwatch.StartNew();
         _ = await service.LaunchGameAsync(730);
-        sw.Stop();
 
         A.CallTo(() => _modeService.ApplyModeAsync("desktop")).MustHaveHappenedOnceExactly();
         A.CallTo(() => _platform.LaunchSteamUrl("steam://rungameid/730")).MustHaveHappened();
-        sw.ElapsedMilliseconds.ShouldBeLessThan(8000);
+        delayMs.ShouldBeEmpty(); // no LaunchApp configured, no delay expected
     }
 
     // ── GetBindings tests ─────────────────────────────────────────

--- a/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/SteamServiceTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using FakeItEasy;
 using HaPcRemote.Service.Configuration;
 using HaPcRemote.Service.Models;
@@ -915,9 +914,7 @@ public class SteamServiceTests
 
     private static void InjectCachedGames(SteamService service, List<SteamGame> games)
     {
-        typeof(SteamService)
-            .GetField("_cachedGames", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .SetValue(service, games);
+        service.SetCachedGamesForTest(games);
     }
 
     [Fact]

--- a/tests/HaPcRemote.Service.Tests/Services/UpdateServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/UpdateServiceTests.cs
@@ -246,9 +246,10 @@ public class UpdateServiceTests
     [Fact]
     public async Task CheckAndApply_ConcurrentCalls_SecondReturnsAlreadyInProgress()
     {
-        // Set up a slow handler so first call blocks
+        // Set up a slow handler so first call blocks; signals when HTTP is entered
+        var httpEntered = new SemaphoreSlim(0, 1);
         var tcs = new TaskCompletionSource<HttpResponseMessage>();
-        var handler = new BlockingHttpMessageHandler(tcs.Task);
+        var handler = new SignalingBlockingHttpMessageHandler(httpEntered, tcs.Task);
         var client = new HttpClient(handler);
         A.CallTo(() => _httpClientFactory.CreateClient("GitHubUpdate")).Returns(client);
 
@@ -257,8 +258,8 @@ public class UpdateServiceTests
         // Start first call (will block on HTTP)
         var first = svc.CheckAndApplyAsync();
 
-        // Small yield to ensure first call acquired the lock
-        await Task.Delay(50);
+        // Wait until the first call has entered the HTTP handler (and thus holds the lock)
+        await httpEntered.WaitAsync();
 
         // Second call should fail immediately
         var second = await svc.CheckAndApplyAsync();
@@ -519,6 +520,17 @@ public class UpdateServiceTests
     {
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
         {
+            return await gate.WaitAsync(ct);
+        }
+    }
+
+    private sealed class SignalingBlockingHttpMessageHandler(
+        SemaphoreSlim signal,
+        Task<HttpResponseMessage> gate) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            signal.Release(); // notify caller that HTTP has been entered (lock is held)
             return await gate.WaitAsync(ct);
         }
     }


### PR DESCRIPTION
## Summary
- T1: Inject delay abstraction into SteamService to remove wall-clock assertion
- T2: Replace Task.Delay(50) race with synchronization primitive in UpdateServiceTests
- T5: Add missing DisableMonitor, SoloMonitor, SetPrimaryMonitor endpoint tests
- T6: Add GetGames and StopGame endpoint tests
- T7: Fix misleading GetGamesAsync_EmptySteamPath_Throws test
- T14: Add Version assertion to integration HealthEndpointTests
- T16: Update cache-warm test to verify warm path skips reload
- T19: Replace reflection-based cache injection with internal test hook
- T20: Remove assertion-free smoke test from LinuxIdleServiceTests
- T15 was already completed in G4

## Test plan
- [ ] All unit tests pass
- [ ] Integration test project builds
- [ ] New endpoint tests follow existing patterns