### PR TITLE
fix: idle overflow, bootstrap logging, middleware hardening

### DIFF
--- a/src/HaPcRemote.Core/HostBootstrapExtensions.cs
+++ b/src/HaPcRemote.Core/HostBootstrapExtensions.cs
@@ -46,8 +46,10 @@ public static class HostBootstrapExtensions
             Directory.CreateDirectory(writableConfigDir);
             configPath = writableConfigPath;
         }
-        catch
+        catch (Exception ex)
         {
+            Console.Error.WriteLine(
+                $"[HA PC Remote] Failed to create config dir '{writableConfigDir}': {ex.Message}. Falling back to app directory.");
             configPath = Path.Combine(AppContext.BaseDirectory, "appsettings.json");
         }
 

--- a/src/HaPcRemote.Core/Middleware/ApiKeyMiddleware.cs
+++ b/src/HaPcRemote.Core/Middleware/ApiKeyMiddleware.cs
@@ -9,8 +9,6 @@ public sealed class ApiKeyMiddleware(RequestDelegate next, ILogger<ApiKeyMiddlew
 {
     private const string ApiKeyHeaderName = "X-Api-Key";
 
-    private static readonly string[] ExemptPaths = ["/api/health"];
-
     public async Task InvokeAsync(HttpContext context, IOptionsMonitor<PcRemoteOptions> options)
     {
         var config = options.CurrentValue;
@@ -23,15 +21,9 @@ public sealed class ApiKeyMiddleware(RequestDelegate next, ILogger<ApiKeyMiddlew
 
         var path = context.Request.Path.Value ?? string.Empty;
 
-        // Artwork image requests are exempt so HA can fetch art without auth.
-        // Diagnostics endpoints under /api/steam/artwork/ are NOT exempt.
-        var isArtworkImageRequest = path.StartsWith("/api/steam/artwork/", StringComparison.OrdinalIgnoreCase)
-            && !path.EndsWith("/diagnostics", StringComparison.OrdinalIgnoreCase);
-
         // Only require auth for /api/ paths; skip non-API requests (favicon.ico, etc.)
         if (!path.StartsWith("/api/", StringComparison.OrdinalIgnoreCase) ||
-            isArtworkImageRequest ||
-            ExemptPaths.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+            IsExemptPath(path))
         {
             await next(context);
             return;
@@ -59,5 +51,18 @@ public sealed class ApiKeyMiddleware(RequestDelegate next, ILogger<ApiKeyMiddlew
         }
 
         await next(context);
+    }
+
+    private static bool IsExemptPath(string path) =>
+        path.Equals("/api/health", StringComparison.OrdinalIgnoreCase) ||
+        IsArtworkImagePath(path);
+
+    private static bool IsArtworkImagePath(string path)
+    {
+        const string prefix = "/api/steam/artwork/";
+        if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+        var segment = path[prefix.Length..];
+        return !segment.Contains('/') && int.TryParse(segment, out _);
     }
 }

--- a/src/HaPcRemote.Core/Services/SteamService.cs
+++ b/src/HaPcRemote.Core/Services/SteamService.cs
@@ -452,6 +452,7 @@ public sealed class SteamService(
     /// <summary>
     /// Seeds the game cache directly. Intended for test use only.
     /// </summary>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     internal void SetCachedGamesForTest(List<SteamGame> games)
     {
         _cachedGames = games;

--- a/src/HaPcRemote.Core/Services/WindowsIdleService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsIdleService.cs
@@ -75,13 +75,13 @@ public sealed partial class WindowsIdleService : IIdleService
         if (!GetLastInputInfo(ref info))
             return null;
 
-        var kbMouseIdleMs = (ulong)Environment.TickCount64 - info.dwTime;
+        var kbMouseIdleMs = (uint)(Environment.TickCount64 & 0xFFFFFFFF) - info.dwTime;
 
         // Gamepad idle — poll all 4 XInput slots
         PollGamepads();
         var gamepadIdleMs = (ulong)(Environment.TickCount64 - LastGamepadInputTick);
 
-        var minIdleMs = Math.Min(kbMouseIdleMs, gamepadIdleMs);
+        var minIdleMs = Math.Min((ulong)kbMouseIdleMs, gamepadIdleMs);
         return (int)(minIdleMs / 1000);
     }
 


### PR DESCRIPTION
## Summary

- **H2** — `WindowsIdleService`: fixed `uint` TickCount arithmetic overflow after 49.7 days; `kbMouseIdleMs` now computed as `uint` subtraction so wrap-around is correct.
- **M3** — `HostBootstrapExtensions.BootstrapApiKey`: silent `catch` block now logs to `Console.Error` with the failed directory path and error message before falling back.
- **M4** — `SteamService.SetCachedGamesForTest`: added `[EditorBrowsable(Never)]` to suppress the test-only helper from IDE completion in production code.
- **M5** — `ApiKeyMiddleware`: replaced fragile negative-match artwork exemption (`.EndsWith("/diagnostics")`) with a positive segment check — only `/api/steam/artwork/{numericId}` (single numeric segment, no sub-paths) is exempt.

## Test plan

- [ ] Build passes (verified locally — 0 errors)
- [ ] Existing test suite passes on CI
- [ ] Confirm `/api/steam/artwork/12345` is exempt from auth
- [ ] Confirm `/api/steam/artwork/12345/diagnostics` requires auth
- [ ] Confirm `/api/health` requires no auth