### PR TITLE
chore: style and efficiency cleanups (L3-L7)

### DIFF
--- a/src/HaPcRemote.Core/Services/CsvParser.cs
+++ b/src/HaPcRemote.Core/Services/CsvParser.cs
@@ -4,7 +4,7 @@ namespace HaPcRemote.Service.Services;
 
 internal static class CsvParser
 {
-    public static List<string> SplitCsvLine(string line)
+    internal static List<string> SplitCsvLine(string line)
     {
         var fields = new List<string>();
         var current = new StringBuilder();

--- a/src/HaPcRemote.Core/Services/MdnsAdvertiserService.cs
+++ b/src/HaPcRemote.Core/Services/MdnsAdvertiserService.cs
@@ -225,6 +225,7 @@ public sealed class MdnsAdvertiserService(IOptionsMonitor<PcRemoteOptions> optio
 
     private byte[] BuildPacket(uint ptrTtl, uint srvTtl, uint txtTtl, uint aTtl)
     {
+        var port = options.CurrentValue.Port;
         using var ms = new MemoryStream(512);
         using var writer = new BinaryWriter(ms);
 
@@ -254,7 +255,7 @@ public sealed class MdnsAdvertiserService(IOptionsMonitor<PcRemoteOptions> optio
         WriteBigEndian(writer, (ushort)(6 + srvTarget.Length));
         WriteBigEndian(writer, 0); // Priority
         WriteBigEndian(writer, 0); // Weight
-        WriteBigEndian(writer, (ushort)options.CurrentValue.Port); // Port
+        WriteBigEndian(writer, (ushort)port); // Port
         writer.Write(srvTarget);
 
         // TXT record

--- a/src/HaPcRemote.Core/Services/SteamArtworkService.cs
+++ b/src/HaPcRemote.Core/Services/SteamArtworkService.cs
@@ -34,9 +34,10 @@ internal static class SteamArtworkService
                 foreach (var ext in ArtworkExtensions)
                 {
                     var path = Path.Combine(gridDir, $"{fileId}p.{ext}");
-                    if (File.Exists(path))
+                    var fi = new FileInfo(path);
+                    if (fi.Exists)
                     {
-                        logger?.LogDebug("Artwork: found in custom grid {Path} ({Size} KB)", path, new FileInfo(path).Length / 1024);
+                        logger?.LogDebug("Artwork: found in custom grid {Path} ({Size} KB)", path, fi.Length / 1024);
                         return path;
                     }
                 }
@@ -63,9 +64,10 @@ internal static class SteamArtworkService
                 foreach (var ext in ArtworkExtensions)
                 {
                     var path = Path.Combine(cacheDir, $"{fileId}{suffix}.{ext}");
-                    if (File.Exists(path))
+                    var fi = new FileInfo(path);
+                    if (fi.Exists)
                     {
-                        logger?.LogDebug("Artwork: found in library cache {Path} ({Size} KB)", path, new FileInfo(path).Length / 1024);
+                        logger?.LogDebug("Artwork: found in library cache {Path} ({Size} KB)", path, fi.Length / 1024);
                         return path;
                     }
                 }
@@ -98,8 +100,9 @@ internal static class SteamArtworkService
             foreach (var ext in ArtworkExtensions)
             {
                 var path = Path.Combine(gridDir, $"{fileId}p.{ext}");
-                var exists = File.Exists(path);
-                long? size = exists ? new FileInfo(path).Length : null;
+                var fii = new FileInfo(path);
+                var exists = fii.Exists;
+                long? size = exists ? fii.Length : null;
                 paths.Add(new ArtworkPathCheck { Path = path, Category = "Custom Grid", Exists = exists, SizeBytes = size });
                 if (exists && resolvedPath == null) resolvedPath = path;
             }
@@ -113,8 +116,9 @@ internal static class SteamArtworkService
             foreach (var ext in ArtworkExtensions)
             {
                 var path = Path.Combine(cacheDir, $"{fileId}{suffix}.{ext}");
-                var exists = File.Exists(path);
-                long? size = exists ? new FileInfo(path).Length : null;
+                var fii = new FileInfo(path);
+                var exists = fii.Exists;
+                long? size = exists ? fii.Length : null;
                 paths.Add(new ArtworkPathCheck { Path = path, Category = $"Library Cache ({suffix})", Exists = exists, SizeBytes = size });
                 if (exists && resolvedPath == null) resolvedPath = path;
             }

--- a/src/HaPcRemote.Core/Views/EmbeddedResourceHelper.cs
+++ b/src/HaPcRemote.Core/Views/EmbeddedResourceHelper.cs
@@ -7,7 +7,7 @@ namespace HaPcRemote.Service.Views;
 public static class EmbeddedResourceHelper
 {
     private static readonly Assembly CurrentAssembly = typeof(EmbeddedResourceHelper).Assembly;
-    private static readonly ConcurrentDictionary<string, string> ResourceCache = new();
+    private static readonly ConcurrentDictionary<string, Lazy<string>> ResourceCache = new();
 
     /// <summary>
     /// Loads an embedded resource file from the Views folder.
@@ -19,7 +19,7 @@ public static class EmbeddedResourceHelper
     {
         var cacheKey = $"Views/{fileName}";
 
-        return ResourceCache.GetOrAdd(cacheKey, _ =>
+        return ResourceCache.GetOrAdd(cacheKey, _ => new Lazy<string>(() =>
         {
             var resourceName = $"HaPcRemote.Service.Views.{fileName}";
             using var stream = CurrentAssembly.GetManifestResourceStream(resourceName)
@@ -27,7 +27,7 @@ public static class EmbeddedResourceHelper
 
             using var reader = new StreamReader(stream, Encoding.UTF8);
             return reader.ReadToEnd();
-        });
+        })).Value;
     }
 
     /// <summary>

--- a/tests/HaPcRemote.Service.Tests/Services/WindowsMonitorServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/WindowsMonitorServiceTests.cs
@@ -371,7 +371,7 @@ public class WindowsMonitorServiceTests
             .MustNotHaveHappened();
     }
 
-        [Fact]
+    [Fact]
     public async Task EnableMonitorAsync_UnknownId_ThrowsKeyNotFoundException()
     {
         SetupTwoMonitorConfig();
@@ -410,7 +410,7 @@ public class WindowsMonitorServiceTests
             .MustNotHaveHappened();
     }
 
-        [Fact]
+    [Fact]
     public async Task DisableMonitorAsync_UnknownId_ThrowsKeyNotFoundException()
     {
         SetupTwoMonitorConfig();


### PR DESCRIPTION
## Summary

- **L3** — `SteamArtworkService`: replace `File.Exists` + `new FileInfo().Length` pairs with a single `FileInfo` instance (both `FindArtworkPath` and `GetArtworkDiagnostics`)
- **L4** — `EmbeddedResourceHelper`: wrap `ConcurrentDictionary` values in `Lazy<string>` to guarantee single factory execution
- **L5** — `MdnsAdvertiserService`: read `options.CurrentValue.Port` once into a local variable in `BuildPacket`
- **L6** — `CsvParser.SplitCsvLine`: change `public static` to `internal static` (method on an `internal` class)
- **L7** — `WindowsMonitorServiceTests`: fix 8-space indented `[Fact]` attributes on `EnableMonitorAsync_UnknownId` and `DisableMonitorAsync_UnknownId` tests