### PR TITLE
fix: auto-update version detection and prerelease comparison (#86)

### DIFF
--- a/src/HaPcRemote.Core/Services/UpdateService.cs
+++ b/src/HaPcRemote.Core/Services/UpdateService.cs
@@ -34,7 +34,7 @@ public sealed class UpdateService(IHttpClientFactory httpClientFactory, ILogger<
     private async Task<UpdateResult> CheckAndApplyInternalAsync(CancellationToken ct)
     {
         var currentVersion = GetCurrentVersion();
-        var currentVersionStr = currentVersion?.ToString(3) ?? "unknown";
+        var currentVersionStr = currentVersion is not null ? FormatVersion(currentVersion) : "unknown";
         var prerelease = IncludePrereleases;
 
         logger.LogInformation("Update check starting - current: {CurrentVersion}, prereleases: {IncludePrereleases}",
@@ -151,23 +151,50 @@ public sealed class UpdateService(IHttpClientFactory httpClientFactory, ILogger<
 
     internal static Version? GetCurrentVersion()
     {
-        var infoVersion = Assembly.GetEntryAssembly()
-            ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var infoVersion = typeof(UpdateService).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
         if (infoVersion is null) return null;
-        var versionPart = infoVersion.Split('+')[0];
-        if (!Version.TryParse(versionPart, out var v)) return null;
-        return v.Build < 0 ? new Version(v.Major, v.Minor, 0) : v;
+        return ParseVersion(infoVersion.Split('+')[0]);
     }
 
-    private static Version? ParseVersion(string tag)
+    /// <summary>
+    /// Parses version strings like "v1.7.0", "1.7.0-rc.3", "v1.7.0-rc.1".
+    /// Prerelease suffix is encoded in the 4th component: "1.7.0-rc.3" → Version(1,7,0,3).
+    /// Stable versions get 4th component = int.MaxValue so they sort higher than any RC.
+    /// </summary>
+    internal static Version? ParseVersion(string tag)
     {
         var cleaned = tag.TrimStart('v');
-        // Strip prerelease suffix (e.g. "1.7.0-rc.1" → "1.7.0")
         var dashIdx = cleaned.IndexOf('-');
-        if (dashIdx >= 0) cleaned = cleaned[..dashIdx];
+        var prerelease = -1;
+
+        if (dashIdx >= 0)
+        {
+            var suffix = cleaned[(dashIdx + 1)..];
+            // Extract trailing number from prerelease suffix (e.g. "rc.3" → 3, "beta.1" → 1)
+            var dotIdx = suffix.LastIndexOf('.');
+            if (dotIdx >= 0 && int.TryParse(suffix[(dotIdx + 1)..], out var n))
+                prerelease = n;
+            else
+                prerelease = 0; // e.g. "beta" with no number
+
+            cleaned = cleaned[..dashIdx];
+        }
+
         if (!Version.TryParse(cleaned, out var v)) return null;
-        return v.Build < 0 ? new Version(v.Major, v.Minor, 0) : v;
+        var major = v.Major;
+        var minor = v.Minor;
+        var patch = v.Build < 0 ? 0 : v.Build;
+
+        // Stable (no dash) → int.MaxValue so v1.7.0 > v1.7.0-rc.99
+        var revision = prerelease < 0 ? int.MaxValue : prerelease;
+        return new Version(major, minor, patch, revision);
     }
+
+    private static string FormatVersion(Version v) =>
+        v.Revision == int.MaxValue
+            ? v.ToString(3)
+            : $"{v.Major}.{v.Minor}.{v.Build}-rc.{v.Revision}";
 
     private HttpClient CreateHttpClient()
     {

--- a/tests/HaPcRemote.Service.Tests/Services/UpdateServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/UpdateServiceTests.cs
@@ -74,13 +74,63 @@ public class UpdateServiceTests
     // ── GetCurrentVersion ─────────────────────────────────────────────
 
     [Fact]
-    public void GetCurrentVersion_InTestContext_ReturnsNullOrValidVersion()
+    public void GetCurrentVersion_ReadsFromServiceAssembly()
     {
-        // In test runner, GetEntryAssembly() may return null or test host assembly.
-        // Either way, it should not throw.
+        // Should read from UpdateService's assembly (HaPcRemote.Core), not entry assembly.
         var version = UpdateService.GetCurrentVersion();
 
-        // No assertion on value — just confirm no exception
+        // In test context the Core assembly has a version set via .csproj
+        version.ShouldNotBeNull();
+    }
+
+    // ── ParseVersion ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("v1.7.0", 1, 7, 0, int.MaxValue)]
+    [InlineData("1.7.0", 1, 7, 0, int.MaxValue)]
+    [InlineData("v1.7.0-rc.1", 1, 7, 0, 1)]
+    [InlineData("v1.7.0-rc.4", 1, 7, 0, 4)]
+    [InlineData("1.7.0-rc.3", 1, 7, 0, 3)]
+    [InlineData("v2.0.0-beta.2", 2, 0, 0, 2)]
+    [InlineData("v1.7.0-alpha", 1, 7, 0, 0)]
+    [InlineData("v1.2", 1, 2, 0, int.MaxValue)]
+    public void ParseVersion_ParsesCorrectly(string tag, int major, int minor, int patch, int revision)
+    {
+        var v = UpdateService.ParseVersion(tag);
+
+        v.ShouldNotBeNull();
+        v!.Major.ShouldBe(major);
+        v.Minor.ShouldBe(minor);
+        v.Build.ShouldBe(patch);
+        v.Revision.ShouldBe(revision);
+    }
+
+    [Fact]
+    public void ParseVersion_InvalidTag_ReturnsNull()
+    {
+        UpdateService.ParseVersion("not-a-version").ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseVersion_StableIsGreaterThanPrerelease()
+    {
+        var stable = UpdateService.ParseVersion("v1.7.0");
+        var rc4 = UpdateService.ParseVersion("v1.7.0-rc.4");
+
+        stable.ShouldNotBeNull();
+        rc4.ShouldNotBeNull();
+        stable.ShouldBeGreaterThan(rc4);
+    }
+
+    [Fact]
+    public void ParseVersion_HigherRcIsGreaterThanLowerRc()
+    {
+        var rc4 = UpdateService.ParseVersion("v1.7.0-rc.4");
+        var rc3 = UpdateService.ParseVersion("v1.7.0-rc.3");
+
+        rc4.ShouldNotBeNull();
+        rc3.ShouldNotBeNull();
+        rc4.ShouldBeGreaterThan(rc3);
     }
 
     // ── ParseVersion via CheckAndApplyAsync ───────────────────────────
@@ -88,29 +138,26 @@ public class UpdateServiceTests
     [Fact]
     public async Task CheckAndApply_TagWithVPrefix_ParsedCorrectly()
     {
-        // v2.0.0 > anything GetCurrentVersion returns in test (null),
-        // so if current is null, result is UpToDate (null version comparison exits early).
-        // We test parse behavior through the returned result.
-        var json = MakeReleaseJson("v2.0.0", "HaPcRemoteService-Setup-2.0.0.exe");
+        var json = MakeReleaseJson("v0.0.1", "HaPcRemoteService-Setup-0.0.1.exe");
         SetupHttpResponse(json);
         var svc = CreateService();
 
         var result = await svc.CheckAndApplyAsync();
 
-        // currentVersion is null in test → latestVersion comparison short-circuits → UpToDate
+        // v0.0.1 < current → UpToDate
         result.Status.ShouldBe(UpdateStatus.UpToDate);
     }
 
     [Fact]
     public async Task CheckAndApply_TagWithoutVPrefix_ParsedCorrectly()
     {
-        var json = MakeReleaseJson("2.0.0", "HaPcRemoteService-Setup-2.0.0.exe");
+        var json = MakeReleaseJson("0.0.1", "HaPcRemoteService-Setup-0.0.1.exe");
         SetupHttpResponse(json);
         var svc = CreateService();
 
         var result = await svc.CheckAndApplyAsync();
 
-        // Same as above: currentVersion null → UpToDate
+        // 0.0.1 < current → UpToDate
         result.Status.ShouldBe(UpdateStatus.UpToDate);
     }
 


### PR DESCRIPTION
## Summary
- `GetCurrentVersion()` used `Assembly.GetEntryAssembly()` which returned null/wrong assembly — now uses `typeof(UpdateService).Assembly` (same as HealthEndpoints)
- `Version.TryParse` rejects SemVer suffixes like `1.7.0-rc.3` — now strips suffix before parsing
- Prerelease ordering: encodes RC number in Version's 4th component (stable = int.MaxValue), so `v1.7.0 > v1.7.0-rc.4 > v1.7.0-rc.3`

Closes #86

## Test plan
- [x] 11 new ParseVersion tests (stable, prerelease, ordering, invalid)
- [x] GetCurrentVersion now returns non-null in test context
- [x] All 432 tests green