### PR TITLE
feat: Compatible display switching mode (#75, #76)

### DIFF
--- a/src/HaPcRemote.Core/Configuration/PcRemoteOptions.cs
+++ b/src/HaPcRemote.Core/Configuration/PcRemoteOptions.cs
@@ -12,6 +12,13 @@ public sealed class PcRemoteOptions
     public Dictionary<string, ModeConfig> Modes { get; set; } = new();
     public PowerSettings Power { get; set; } = new();
     public SteamConfig Steam { get; set; } = new();
+    public DisplaySwitchingMode DisplaySwitching { get; set; } = DisplaySwitchingMode.Direct;
+}
+
+public enum DisplaySwitchingMode
+{
+    Direct,
+    Compatible
 }
 
 public sealed class PowerSettings

--- a/src/HaPcRemote.Core/Services/ConfigurationWriter.cs
+++ b/src/HaPcRemote.Core/Services/ConfigurationWriter.cs
@@ -62,6 +62,9 @@ public sealed class ConfigurationWriter(string configPath) : IConfigurationWrite
     public void SaveApp(string key, AppDefinitionOptions app)
         => ModifyAndWrite(o => o.Apps[key] = app);
 
+    public void SaveDisplaySwitching(DisplaySwitchingMode mode)
+        => ModifyAndWrite(o => o.DisplaySwitching = mode);
+
 
     private void ModifyAndWrite(Action<PcRemoteOptions> modifier)
     {

--- a/src/HaPcRemote.Core/Services/IConfigurationWriter.cs
+++ b/src/HaPcRemote.Core/Services/IConfigurationWriter.cs
@@ -34,4 +34,7 @@ public interface IConfigurationWriter
 
     /// <summary>Add or update a single app definition by key.</summary>
     void SaveApp(string key, AppDefinitionOptions app);
+
+    /// <summary>Update the display switching mode.</summary>
+    void SaveDisplaySwitching(DisplaySwitchingMode mode);
 }

--- a/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
@@ -1,8 +1,10 @@
 using System.ComponentModel;
 using System.Runtime.Versioning;
+using HaPcRemote.Service.Configuration;
 using HaPcRemote.Service.Models;
 using HaPcRemote.Service.Native;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using static HaPcRemote.Service.Native.DisplayConfigApi;
 
 namespace HaPcRemote.Service.Services;
@@ -14,6 +16,7 @@ internal sealed class WindowsMonitorService : IMonitorService
 
     private readonly IDisplayConfigApi _api;
     private readonly ILogger<WindowsMonitorService> _logger;
+    private readonly IOptionsMonitor<PcRemoteOptions> _options;
     private readonly SemaphoreSlim _cacheLock = new(1, 1);
 
     private List<MonitorInfo>? _cachedMonitors;
@@ -22,10 +25,15 @@ internal sealed class WindowsMonitorService : IMonitorService
     // Maps MonitorId (e.g. "GSM59A4") → native (adapterId, targetId) for path resolution
     private readonly Dictionary<string, (LUID adapterId, uint targetId)> _targetKeys = new(StringComparer.OrdinalIgnoreCase);
 
-    public WindowsMonitorService(IDisplayConfigApi api, ILogger<WindowsMonitorService> logger)
+    private const int MaxVerifyAttempts = 3;
+
+    internal bool UseCompatibleMode => _options.CurrentValue.DisplaySwitching == DisplaySwitchingMode.Compatible;
+
+    public WindowsMonitorService(IDisplayConfigApi api, ILogger<WindowsMonitorService> logger, IOptionsMonitor<PcRemoteOptions> options)
     {
         _api = api;
         _logger = logger;
+        _options = options;
     }
 
     // ── Query ─────────────────────────────────────────────────────────
@@ -175,6 +183,8 @@ internal sealed class WindowsMonitorService : IMonitorService
 
     public async Task EnableMonitorAsync(string id)
     {
+        if (UseCompatibleMode) { await EnableCompatibleAsync(id); return; }
+
         var monitors = await GetMonitorsAsync();
         var target = FindMonitor(monitors, id);
 
@@ -187,20 +197,14 @@ internal sealed class WindowsMonitorService : IMonitorService
         _logger.LogInformation("Enabling monitor: {Name} ({Id})", target.MonitorName, target.MonitorId);
 
         var targetKey = ResolveTargetKey(target);
-        ApplyWithRetry(() =>
-        {
-            var (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
-            var idx = FindPathIndex(paths, targetKey);
-            paths[idx].flags |= DISPLAYCONFIG_PATH_FLAGS.ACTIVE;
-            paths[idx].sourceInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
-            paths[idx].targetInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
-            return (paths, modes);
-        });
+        ApplyWithRetry(() => BuildEnableConfig(targetKey));
         InvalidateCache();
     }
 
     public async Task DisableMonitorAsync(string id)
     {
+        if (UseCompatibleMode) { await DisableCompatibleAsync(id); return; }
+
         var monitors = await GetMonitorsAsync();
         var target = FindMonitor(monitors, id);
 
@@ -213,18 +217,14 @@ internal sealed class WindowsMonitorService : IMonitorService
         _logger.LogInformation("Disabling monitor: {Name} ({Id})", target.MonitorName, target.MonitorId);
 
         var targetKey = ResolveTargetKey(target);
-        ApplyWithRetry(() =>
-        {
-            var (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
-            var idx = FindPathIndex(paths, targetKey);
-            paths[idx].flags &= ~DISPLAYCONFIG_PATH_FLAGS.ACTIVE;
-            return (paths, modes);
-        });
+        ApplyWithRetry(() => BuildDisableConfig(targetKey));
         InvalidateCache();
     }
 
     public async Task SetPrimaryAsync(string id)
     {
+        if (UseCompatibleMode) { await SetPrimaryCompatibleAsync(id); return; }
+
         var monitors = await GetMonitorsAsync();
         var target = FindMonitor(monitors, id);
         _logger.LogInformation("Setting primary monitor: {Name} ({Id})", target.MonitorName, target.MonitorId);
@@ -239,6 +239,26 @@ internal sealed class WindowsMonitorService : IMonitorService
         var targetKey = ResolveTargetKey(target);
         ApplyWithRetry(() => BuildSetPrimaryConfig(targetKey, id));
         InvalidateCache();
+    }
+
+    private (DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes) BuildEnableConfig(
+        (LUID adapterId, uint targetId) targetKey)
+    {
+        var (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
+        var idx = FindPathIndex(paths, targetKey);
+        paths[idx].flags |= DISPLAYCONFIG_PATH_FLAGS.ACTIVE;
+        paths[idx].sourceInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+        paths[idx].targetInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+        return (paths, modes);
+    }
+
+    private (DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes) BuildDisableConfig(
+        (LUID adapterId, uint targetId) targetKey)
+    {
+        var (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
+        var idx = FindPathIndex(paths, targetKey);
+        paths[idx].flags &= ~DISPLAYCONFIG_PATH_FLAGS.ACTIVE;
+        return (paths, modes);
     }
 
     private (DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes) BuildSetPrimaryConfig(
@@ -281,6 +301,8 @@ internal sealed class WindowsMonitorService : IMonitorService
 
     public async Task SoloMonitorAsync(string id)
     {
+        if (UseCompatibleMode) { await SoloCompatibleAsync(id); return; }
+
         var monitors = await GetMonitorsAsync();
         var target = FindMonitor(monitors, id);
 
@@ -335,6 +357,157 @@ internal sealed class WindowsMonitorService : IMonitorService
         return (paths, modes);
     }
 
+    // ── Compatible mode ────────────────────────────────────────────────
+
+    private async Task SoloCompatibleAsync(string id)
+    {
+        _logger.LogInformation("Solo monitor (compatible): {Id}", id);
+
+        // Step 1: Enable target if not active
+        var monitors = InvalidateAndQueryMonitors();
+        var target = FindMonitor(monitors, id);
+        if (!target.IsActive)
+        {
+            await EnableCompatibleAsync(id);
+            monitors = InvalidateAndQueryMonitors();
+            target = FindMonitor(monitors, id);
+        }
+
+        // Step 2: Set primary (doesn't change which monitors are active)
+        if (!target.IsPrimary)
+            await SetPrimaryCompatibleAsync(id);
+
+        // Step 3: Disable each other active monitor
+        var others = monitors.Where(m => m.IsActive && !MatchesId(m, id)).ToList();
+        foreach (var other in others)
+        {
+            await DisableCompatibleAsync(other.MonitorId);
+        }
+
+        // Final verification
+        var final = InvalidateAndQueryMonitors();
+        var active = final.Where(m => m.IsActive).ToList();
+        if (active.Count != 1 || !MatchesId(active[0], id))
+        {
+            var activeNames = string.Join(", ", active.Select(m => $"{m.MonitorName} ({m.MonitorId})"));
+            _logger.LogWarning("Solo compatible '{Id}' — unexpected result: [{Active}]", id, activeNames);
+        }
+    }
+
+    private async Task EnableCompatibleAsync(string id)
+    {
+        var monitors = InvalidateAndQueryMonitors();
+        var target = FindMonitor(monitors, id);
+
+        if (target.IsActive)
+        {
+            _logger.LogInformation("Monitor '{Id}' is already enabled, skipping (compatible)", id);
+            return;
+        }
+
+        _logger.LogInformation("Enabling monitor (compatible): {Name} ({Id})", target.MonitorName, target.MonitorId);
+
+        var targetKey = ResolveTargetKey(target);
+        await ApplyStepWithVerification(
+            () => BuildEnableConfig(targetKey),
+            () => FindMonitor(QueryMonitors(), id).IsActive,
+            $"Enable({id})");
+    }
+
+    private async Task SetPrimaryCompatibleAsync(string id)
+    {
+        var monitors = InvalidateAndQueryMonitors();
+        var target = FindMonitor(monitors, id);
+
+        if (!target.IsActive)
+        {
+            _logger.LogInformation("Monitor '{Id}' not active — enabling first (compatible)", id);
+            await EnableCompatibleAsync(id);
+            monitors = InvalidateAndQueryMonitors();
+            target = FindMonitor(monitors, id);
+        }
+
+        if (target.IsPrimary)
+        {
+            _logger.LogDebug("Monitor {Id} is already primary (compatible)", id);
+            return;
+        }
+
+        _logger.LogInformation("Setting primary (compatible): {Name} ({Id})", target.MonitorName, target.MonitorId);
+
+        var targetKey = ResolveTargetKey(target);
+        await ApplyStepWithVerification(
+            () => BuildSetPrimaryConfig(targetKey, id),
+            () => FindMonitor(QueryMonitors(), id).IsPrimary,
+            $"SetPrimary({id})");
+    }
+
+    private async Task DisableCompatibleAsync(string id)
+    {
+        var monitors = InvalidateAndQueryMonitors();
+        var target = FindMonitor(monitors, id);
+
+        if (!target.IsActive)
+        {
+            _logger.LogInformation("Monitor '{Id}' is already disabled, skipping (compatible)", id);
+            return;
+        }
+
+        // If disabling the primary, move primary to another active monitor first
+        if (target.IsPrimary)
+        {
+            var other = monitors.FirstOrDefault(m => m.IsActive && !MatchesId(m, id));
+            if (other != null)
+            {
+                _logger.LogInformation("Shuffling primary to {Other} before disabling {Id} (compatible)", other.MonitorId, id);
+                await SetPrimaryCompatibleAsync(other.MonitorId);
+            }
+        }
+
+        _logger.LogInformation("Disabling monitor (compatible): {Name} ({Id})", target.MonitorName, target.MonitorId);
+
+        var targetKey = ResolveTargetKey(target);
+        await ApplyStepWithVerification(
+            () => BuildDisableConfig(targetKey),
+            () => !FindMonitor(QueryMonitors(), id).IsActive,
+            $"Disable({id})");
+    }
+
+    private async Task ApplyStepWithVerification(
+        Func<(DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes)> buildConfig,
+        Func<bool> verify,
+        string stepName)
+    {
+        for (var attempt = 0; attempt < MaxVerifyAttempts; attempt++)
+        {
+            ApplyWithRetry(buildConfig);
+            InvalidateCache();
+
+            if (attempt > 0 && StepDelayMs > 0)
+                await Task.Delay(StepDelayMs);
+
+            if (verify())
+            {
+                _logger.LogDebug("Step {Step} verified successfully", stepName);
+                return;
+            }
+
+            _logger.LogWarning("Step {Step} verification failed, retrying ({Attempt}/{Max})",
+                stepName, attempt + 1, MaxVerifyAttempts);
+
+            if (StepDelayMs > 0)
+                await Task.Delay(StepDelayMs);
+        }
+
+        _logger.LogWarning("Step {Step} could not be verified after {Max} attempts", stepName, MaxVerifyAttempts);
+    }
+
+    private List<MonitorInfo> InvalidateAndQueryMonitors()
+    {
+        InvalidateCache();
+        return QueryMonitors();
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────
 
     internal void InvalidateCache()
@@ -343,6 +516,7 @@ internal sealed class WindowsMonitorService : IMonitorService
     }
 
     internal int[] RetryDelaysMs = [500, 1000, 2000];
+    internal int StepDelayMs = 500;
 
     /// <summary>
     /// Applies a display config change with retry logic for transient driver errors.

--- a/src/HaPcRemote.Tray/Forms/GamesTab.cs
+++ b/src/HaPcRemote.Tray/Forms/GamesTab.cs
@@ -44,14 +44,7 @@ internal sealed class GamesTab : TabPage, ISettingsTab
         layout.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
 
         // Default PC mode
-        _defaultModeCombo = new ComboBox
-        {
-            DropDownStyle = ComboBoxStyle.DropDownList,
-            Width = 200,
-            BackColor = Color.FromArgb(50, 50, 50),
-            ForeColor = Color.White,
-            FlatStyle = FlatStyle.Flat
-        };
+        _defaultModeCombo = TabHelpers.MakeComboBox();
         layout.Controls.Add(MakeLabel("Default PC Mode:"), 0, 0);
         var defaultModePanel = new FlowLayoutPanel { FlowDirection = FlowDirection.LeftToRight, AutoSize = true };
         defaultModePanel.Controls.Add(_defaultModeCombo);

--- a/src/HaPcRemote.Tray/Forms/GeneralTab.cs
+++ b/src/HaPcRemote.Tray/Forms/GeneralTab.cs
@@ -19,6 +19,8 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
     private readonly Label _portStatusLabel;
     private readonly Button _portSaveButton;
     private readonly Label _soundVolumeViewLabel;
+    private readonly ComboBox _displaySwitchingCombo;
+    private readonly IConfigurationWriter _configWriter;
     private readonly int _currentPort;
 
     public GeneralTab(IServiceProvider services)
@@ -29,6 +31,7 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
         Padding = new Padding(20);
 
         _restartService = services.GetRequiredService<KestrelRestartService>();
+        _configWriter = services.GetRequiredService<IConfigurationWriter>();
         var options = services.GetRequiredService<IOptions<PcRemoteOptions>>().Value;
         _currentPort = options.Port;
 
@@ -96,18 +99,24 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
 
         UpdateToolStatus(_soundVolumeViewLabel, Path.Combine(options.ToolsPath, "SoundVolumeView.exe"));
 
+        // Display switching mode
+        _displaySwitchingCombo = TabHelpers.MakeComboBox();
+        _displaySwitchingCombo.Items.AddRange(Enum.GetNames<DisplaySwitchingMode>());
+        _displaySwitchingCombo.SelectedItem = options.DisplaySwitching.ToString();
+        var displaySwitchingPanel = new FlowLayoutPanel { FlowDirection = FlowDirection.LeftToRight, AutoSize = true };
+        displaySwitchingPanel.Controls.Add(_displaySwitchingCombo);
+        displaySwitchingPanel.Controls.Add(MakeHelpIcon(_toolTip,
+            "How monitor changes are applied.\n" +
+            "Direct: single API call (fastest, works on most hardware)\n" +
+            "Compatible: sequential steps with verification (use if Direct fails)"));
+        layout.Controls.Add(MakeLabel("Display Switching:"), 0, row);
+        layout.Controls.Add(displaySwitchingPanel, 1, row++);
+
         // Separator
         layout.Controls.Add(new Label { AutoSize = true, Height = 10 }, 0, row++);
 
         // Log level
-        _logLevelCombo = new ComboBox
-        {
-            DropDownStyle = ComboBoxStyle.DropDownList,
-            Width = 200,
-            BackColor = Color.FromArgb(50, 50, 50),
-            ForeColor = Color.White,
-            FlatStyle = FlatStyle.Flat
-        };
+        _logLevelCombo = TabHelpers.MakeComboBox();
         _logLevelCombo.Items.AddRange(["Error", "Warning", "Info", "Verbose"]);
 
         var settings = TraySettings.Load();
@@ -272,6 +281,10 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
         s.AutoUpdate = _autoUpdateCheck.Checked;
         s.IncludePrereleases = _includePrereleasesCheck.Checked;
         s.Save();
+
+        var displayMode = Enum.TryParse<DisplaySwitchingMode>(_displaySwitchingCombo.SelectedItem?.ToString(), out var dm)
+            ? dm : DisplaySwitchingMode.Direct;
+        _configWriter.SaveDisplaySwitching(displayMode);
     }
 
     private void OnCancel(object? sender, EventArgs e)
@@ -286,5 +299,7 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
         };
         _autoUpdateCheck.Checked = s.AutoUpdate;
         _includePrereleasesCheck.Checked = s.IncludePrereleases;
+
+        _displaySwitchingCombo.SelectedItem = _configWriter.Read().DisplaySwitching.ToString();
     }
 }

--- a/src/HaPcRemote.Tray/Forms/LogTab.cs
+++ b/src/HaPcRemote.Tray/Forms/LogTab.cs
@@ -50,7 +50,7 @@ internal sealed class LogTab : TabPage, ISettingsTab
             catch { /* best effort */ }
         };
 
-        return [clearButton, debugButton];
+        return [debugButton, clearButton];
     }
 
     private void OnNewLogEntry(LogEntry entry)

--- a/src/HaPcRemote.Tray/Forms/ModesTab.cs
+++ b/src/HaPcRemote.Tray/Forms/ModesTab.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 
 namespace HaPcRemote.Tray.Forms;
 
-internal sealed class ModesTab : TabPage
+internal sealed class ModesTab : TabPage, ISettingsTab
 {
     private readonly IConfigurationWriter _configWriter;
     private readonly IAudioService _audioService;
@@ -91,26 +91,12 @@ internal sealed class ModesTab : TabPage
         editLayout.Controls.Add(WithHelp(_modeNameBox, _toolTip, "Unique identifier for this mode.\nUsed in HA automations and the PC Mode select entity.\nExample: couch, desktop"), 1, row++);
 
         // Audio device (with "Don't change" option)
-        _audioDeviceCombo = new ComboBox
-        {
-            DropDownStyle = ComboBoxStyle.DropDownList,
-            Width = 250,
-            BackColor = Color.FromArgb(50, 50, 50),
-            ForeColor = Color.White,
-            FlatStyle = FlatStyle.Flat
-        };
+        _audioDeviceCombo = TabHelpers.MakeComboBox(250);
         editLayout.Controls.Add(MakeLabel("Audio Device:"), 0, row);
         editLayout.Controls.Add(WithHelp(_audioDeviceCombo, _toolTip, "Audio output to switch to when this mode is activated.\nSelect \"(Don't change)\" to leave the current device untouched."), 1, row++);
 
         // Solo monitor
-        _soloMonitorCombo = new ComboBox
-        {
-            DropDownStyle = ComboBoxStyle.DropDownList,
-            Width = 250,
-            BackColor = Color.FromArgb(50, 50, 50),
-            ForeColor = Color.White,
-            FlatStyle = FlatStyle.Flat
-        };
+        _soloMonitorCombo = TabHelpers.MakeComboBox(250);
         editLayout.Controls.Add(MakeLabel("Solo Monitor:"), 0, row);
         editLayout.Controls.Add(WithHelp(_soloMonitorCombo, _toolTip, "Monitor to keep as sole active display. Disables all others."), 1, row++);
 
@@ -126,39 +112,19 @@ internal sealed class ModesTab : TabPage
         editLayout.Controls.Add(volumePanel, 1, row++);
 
         // Launch app
-        _launchAppCombo = new ComboBox
-        {
-            DropDownStyle = ComboBoxStyle.DropDown,
-            Width = 250,
-            BackColor = Color.FromArgb(50, 50, 50),
-            ForeColor = Color.White,
-            FlatStyle = FlatStyle.Flat
-        };
+        _launchAppCombo = TabHelpers.MakeComboBox(250, ComboBoxStyle.DropDown);
         editLayout.Controls.Add(MakeLabel("Launch App:"), 0, row);
         editLayout.Controls.Add(WithHelp(_launchAppCombo, _toolTip, "App to launch when this mode is activated.\nApps are defined in the Apps config section."), 1, row++);
 
         // Kill app
-        _killAppCombo = new ComboBox
-        {
-            DropDownStyle = ComboBoxStyle.DropDown,
-            Width = 250,
-            BackColor = Color.FromArgb(50, 50, 50),
-            ForeColor = Color.White,
-            FlatStyle = FlatStyle.Flat
-        };
+        _killAppCombo = TabHelpers.MakeComboBox(250, ComboBoxStyle.DropDown);
         editLayout.Controls.Add(MakeLabel("Kill App:"), 0, row);
         editLayout.Controls.Add(WithHelp(_killAppCombo, _toolTip, "App to terminate when this mode is activated.\nUseful for killing Steam Big Picture when switching to desktop mode."), 1, row++);
 
         rightPanel.Controls.Add(editLayout);
 
-        var saveButton = TabFooter.MakeSaveButton("Save Mode", 100);
-        saveButton.Click += OnSaveMode;
-        var footer = new TabFooter();
-        footer.Add(saveButton);
-
         Controls.Add(rightPanel);
         Controls.Add(leftPanel);
-        Controls.Add(footer);
 
         LoadModes();
     }
@@ -319,6 +285,13 @@ internal sealed class ModesTab : TabPage
 
         ResetEditorFields();
         _modeNameBox.Focus();
+    }
+
+    public IEnumerable<Button> CreateFooterButtons()
+    {
+        var applyButton = TabFooter.MakeSaveButton("Apply");
+        applyButton.Click += OnSaveMode;
+        return [applyButton];
     }
 
     private void OnSaveMode(object? sender, EventArgs e)

--- a/src/HaPcRemote.Tray/Forms/SettingsForm.cs
+++ b/src/HaPcRemote.Tray/Forms/SettingsForm.cs
@@ -55,8 +55,7 @@ internal sealed class SettingsForm : Form
         _tabControl.TabPages.Add(_powerTab);
         _tabControl.TabPages.Add(_logTab);
 
-        // Shared footer — buttons swap when the selected tab changes.
-        // ModesTab manages its own footer internally (it has row-management buttons).
+        // Shared footer — buttons swap when the selected tab changes
         _footer = new TabFooter();
         _tabControl.SelectedIndexChanged += (_, _) => SyncFooter();
 
@@ -78,7 +77,6 @@ internal sealed class SettingsForm : Form
         }
         else
         {
-            // ModesTab (or any tab without ISettingsTab) — hide the shared footer
             _footer.Visible = false;
         }
     }

--- a/src/HaPcRemote.Tray/Forms/TabHelpers.cs
+++ b/src/HaPcRemote.Tray/Forms/TabHelpers.cs
@@ -29,6 +29,15 @@ internal static class TabHelpers
         return label;
     }
 
+    public static ComboBox MakeComboBox(int width = 200, ComboBoxStyle style = ComboBoxStyle.DropDownList) => new()
+    {
+        DropDownStyle = style,
+        Width = width,
+        BackColor = Color.FromArgb(50, 50, 50),
+        ForeColor = Color.White,
+        FlatStyle = FlatStyle.Flat
+    };
+
     public static LogLevel ParseLogLevel(string level) => level switch
     {
         "Error"   => LogLevel.Error,

--- a/tests/HaPcRemote.Service.Tests/Services/LinuxMonitorServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/LinuxMonitorServiceTests.cs
@@ -68,20 +68,15 @@ public class LinuxMonitorServiceTests
     // ── EnableMonitorAsync tests ─────────────────────────────────────
 
     [Fact]
-    public async Task EnableMonitorAsync_CallsXrandrAuto()
+    public async Task EnableMonitorAsync_UnknownId_ThrowsKeyNotFoundException()
     {
         A.CallTo(() => _cliRunner.RunAsync("xrandr",
             A<IEnumerable<string>>.That.Contains("--listmonitors"), A<int>._))
             .Returns("Monitors: 1\n 0: +*DP-0 2560/597x1440/336+0+0  DP-0\n");
 
         var service = CreateService();
-        await service.GetMonitorsAsync(); // prime cache
-        await service.EnableMonitorAsync("DP-0");
 
-        A.CallTo(() => _cliRunner.RunAsync("xrandr",
-            A<IEnumerable<string>>.That.Matches(a =>
-                a.Contains("--output") && a.Contains("DP-0") && a.Contains("--auto")),
-            A<int>._)).MustHaveHappenedOnceExactly();
+        await Should.ThrowAsync<KeyNotFoundException>(() => service.EnableMonitorAsync("UNKNOWN"));
     }
 
     // ── DisableMonitorAsync tests ────────────────────────────────────

--- a/tests/HaPcRemote.Service.Tests/Services/WindowsMonitorServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/WindowsMonitorServiceTests.cs
@@ -1,9 +1,11 @@
 using System.ComponentModel;
 using FakeItEasy;
+using HaPcRemote.Service.Configuration;
 using HaPcRemote.Service.Models;
 using HaPcRemote.Service.Native;
 using HaPcRemote.Service.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using static HaPcRemote.Service.Native.DisplayConfigApi;
 
@@ -14,7 +16,22 @@ public class WindowsMonitorServiceTests
     private readonly IDisplayConfigApi _api = A.Fake<IDisplayConfigApi>();
     private readonly ILogger<WindowsMonitorService> _logger = A.Fake<ILogger<WindowsMonitorService>>();
 
-    private WindowsMonitorService CreateService() => new(_api, _logger);
+    private static IOptionsMonitor<PcRemoteOptions> MakeOptions(DisplaySwitchingMode mode = DisplaySwitchingMode.Direct)
+    {
+        var options = A.Fake<IOptionsMonitor<PcRemoteOptions>>();
+        A.CallTo(() => options.CurrentValue).Returns(new PcRemoteOptions { DisplaySwitching = mode });
+        return options;
+    }
+
+    private WindowsMonitorService CreateService() => new(_api, _logger, MakeOptions());
+
+    private WindowsMonitorService CreateCompatibleService()
+    {
+        var service = new WindowsMonitorService(_api, _logger, MakeOptions(DisplaySwitchingMode.Compatible));
+        service.RetryDelaysMs = [0, 0, 0];
+        service.StepDelayMs = 0;
+        return service;
+    }
 
     // ── Test data builders ────────────────────────────────────────────
 
@@ -697,7 +714,7 @@ public class WindowsMonitorServiceTests
 
     private WindowsMonitorService CreateServiceWithNoRetryDelay()
     {
-        var service = new WindowsMonitorService(_api, _logger);
+        var service = new WindowsMonitorService(_api, _logger, MakeOptions());
         service.RetryDelaysMs = [0, 0, 0];
         return service;
     }
@@ -883,5 +900,192 @@ public class WindowsMonitorServiceTests
         var rational = new DISPLAYCONFIG_RATIONAL { Numerator = numerator, Denominator = denominator };
 
         rational.ToHz().ShouldBe(expected);
+    }
+
+    // ── Compatible mode ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Compatible_SoloMonitorAsync_CallsApplyMultipleTimes()
+    {
+        SetupTwoMonitorConfig();
+        var service = CreateCompatibleService();
+
+        var applyCount = 0;
+        A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
+            .Invokes(() => applyCount++);
+
+        await service.SoloMonitorAsync("DEL4321");
+
+        // Should call Apply multiple times (set primary + disable other)
+        applyCount.ShouldBeGreaterThan(1);
+    }
+
+    [Fact]
+    public async Task Compatible_SoloMonitorAsync_SkipsEnableIfTargetAlreadyActive()
+    {
+        SetupTwoMonitorConfig();
+        var service = CreateCompatibleService();
+
+        var applyCallPaths = new List<DISPLAYCONFIG_PATH_INFO[]>();
+        A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
+            .Invokes((DISPLAYCONFIG_PATH_INFO[] p, DISPLAYCONFIG_MODE_INFO[] _, SetDisplayConfigFlags _) =>
+                applyCallPaths.Add(p));
+
+        await service.SoloMonitorAsync("GSM59A4"); // already active + primary
+
+        // Only the disable step for the other monitor
+        applyCallPaths.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Compatible_EnableMonitorAsync_NoOpIfAlreadyActive()
+    {
+        SetupTwoMonitorConfig();
+        var service = CreateCompatibleService();
+
+        await service.EnableMonitorAsync("GSM59A4"); // already active
+
+        A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task Compatible_DisableMonitorAsync_ShufflesPrimaryFirst()
+    {
+        SetupTwoMonitorConfig();
+        var service = CreateCompatibleService();
+
+        var applyCount = 0;
+        A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
+            .Invokes(() => applyCount++);
+
+        // GSM59A4 is the primary — disabling it should set DEL4321 as primary first
+        await service.DisableMonitorAsync("GSM59A4");
+
+        // At least 2 calls: SetPrimary(DEL4321) + Disable(GSM59A4)
+        applyCount.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public async Task Compatible_SetPrimaryAsync_EnablesFirstIfInactive()
+    {
+        var service = CreateCompatibleService();
+
+        // Start with DEL4321 inactive; after first ApplyConfig (Enable), switch to both active
+        var applyCount = 0;
+        A.CallTo(() => _api.QueryConfig(A<QueryDisplayConfigFlags>._))
+            .ReturnsLazily(() =>
+            {
+                if (applyCount > 0)
+                {
+                    // After Enable: both active, GSM59A4 at (0,0), DEL4321 at (3840,0)
+                    return (
+                        new[]
+                        {
+                            MakeActivePath(Adapter1, targetId: 10, sourceId: 0, sourceModeIdx: 0, targetModeIdx: 1),
+                            MakeActivePath(Adapter1, targetId: 20, sourceId: 1, sourceModeIdx: 2, targetModeIdx: 3),
+                        },
+                        new[]
+                        {
+                            MakeSourceMode(Adapter1, 0, 3840, 2160, 0, 0),
+                            MakeTargetMode(Adapter1, 10, 120000, 1000),
+                            MakeSourceMode(Adapter1, 1, 2560, 1440, 3840, 0),
+                            MakeTargetMode(Adapter1, 20, 60000, 1000),
+                        });
+                }
+                // Initial: DEL4321 inactive
+                return (
+                    new[]
+                    {
+                        MakeActivePath(Adapter1, targetId: 10, sourceId: 0, sourceModeIdx: 0, targetModeIdx: 1),
+                        MakeInactivePath(Adapter1, targetId: 20, sourceId: 1),
+                    },
+                    new[]
+                    {
+                        MakeSourceMode(Adapter1, 0, 3840, 2160, 0, 0),
+                        MakeTargetMode(Adapter1, 10, 120000, 1000),
+                    });
+            });
+
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 10)).Returns(("LG ULTRAGEAR", (ushort)0x6D1E, (ushort)0x59A4));
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 20)).Returns(("Dell U2723QE", (ushort)0xAC10, (ushort)0x4321));
+        A.CallTo(() => _api.GetSourceGdiName(Adapter1, 0)).Returns(@"\\.\DISPLAY1");
+        A.CallTo(() => _api.GetSourceGdiName(Adapter1, 1)).Returns(@"\\.\DISPLAY2");
+
+        A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
+            .Invokes(() => applyCount++);
+
+        await service.SetPrimaryAsync("DEL4321"); // inactive
+
+        // At least 2 calls: Enable + SetPrimary
+        applyCount.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public async Task Compatible_VerificationFailure_Retries()
+    {
+        SetupOneActiveOneInactive();
+        var service = CreateCompatibleService();
+
+        // First Apply succeeds but verification fails (still shows inactive)
+        var queryCount = 0;
+        A.CallTo(() => _api.QueryConfig(A<QueryDisplayConfigFlags>._))
+            .ReturnsLazily(() =>
+            {
+                queryCount++;
+                // After enough queries, return the monitor as active
+                if (queryCount >= 5)
+                {
+                    var activePaths = new[]
+                    {
+                        MakeActivePath(Adapter1, targetId: 10, sourceId: 0, sourceModeIdx: 0, targetModeIdx: 1),
+                        MakeActivePath(Adapter1, targetId: 20, sourceId: 1, sourceModeIdx: 2, targetModeIdx: 3),
+                    };
+                    var activeModes = new[]
+                    {
+                        MakeSourceMode(Adapter1, 0, 3840, 2160, 0, 0),
+                        MakeTargetMode(Adapter1, 10, 120000, 1000),
+                        MakeSourceMode(Adapter1, 1, 2560, 1440, 3840, 0),
+                        MakeTargetMode(Adapter1, 20, 60000, 1000),
+                    };
+                    return (activePaths, activeModes);
+                }
+
+                // Return original inactive config
+                var paths = new[]
+                {
+                    MakeActivePath(Adapter1, targetId: 10, sourceId: 0, sourceModeIdx: 0, targetModeIdx: 1),
+                    MakeInactivePath(Adapter1, targetId: 20, sourceId: 1),
+                };
+                var modes = new[]
+                {
+                    MakeSourceMode(Adapter1, 0, 3840, 2160, 0, 0),
+                    MakeTargetMode(Adapter1, 10, 120000, 1000),
+                };
+                return (paths, modes);
+            });
+
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 10)).Returns(("LG ULTRAGEAR", (ushort)0x6D1E, (ushort)0x59A4));
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 20)).Returns(("Dell U2723QE", (ushort)0xAC10, (ushort)0x4321));
+        A.CallTo(() => _api.GetSourceGdiName(Adapter1, 0)).Returns(@"\\.\DISPLAY1");
+        A.CallTo(() => _api.GetSourceGdiName(Adapter1, 1)).Returns(@"\\.\DISPLAY2");
+
+        await service.EnableMonitorAsync("DEL4321");
+
+        // Should have called ApplyConfig at least 2 times (first attempt + retry after verification failure)
+        A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
+            .MustHaveHappened(2, Times.OrMore);
+    }
+
+    [Fact]
+    public async Task Direct_SoloMonitorAsync_UnchangedBehavior_SingleApplyCall()
+    {
+        SetupTwoMonitorConfig();
+        var service = CreateService(); // Direct mode (default)
+
+        await service.SoloMonitorAsync("GSM59A4");
+
+        A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
+            .MustHaveHappenedOnceExactly();
     }
 }


### PR DESCRIPTION
## Summary
- Adds `DisplaySwitchingMode` setting (Direct/Compatible) for hardware that fails complex single-call topology changes with error 31
- Compatible mode breaks Solo/Enable/Disable/SetPrimary into sequential sub-steps with verification and retry
- Direct mode (default) is completely unchanged

## Also includes
- **UI**: Extract `TabHelpers.MakeComboBox` replacing 7 duplicated ComboBox blocks
- **UI**: Move ModesTab "Save Mode" → "Apply" in shared footer bar
- **UI**: Swap LogTab footer button order (API Explorer before Clear)
- **Fix**: Broken `LinuxMonitorServiceTests.EnableMonitorAsync_CallsXrandrAuto` test

## Test plan
- [x] 439/439 unit tests green
- [ ] Toggle Display Switching to Compatible, trigger Solo from HA, check logs for multi-step sequence
- [ ] Verify Direct mode still works unchanged