### PR TITLE
Release 1.7.2: display config enhancements & audio device visibility

### DIFF
--- a/src/HaPcRemote.Core/AppJsonContext.cs
+++ b/src/HaPcRemote.Core/AppJsonContext.cs
@@ -37,6 +37,8 @@ namespace HaPcRemote.Service;
 [JsonSerializable(typeof(ApiResponse<SystemState>))]
 [JsonSerializable(typeof(PowerConfig))]
 [JsonSerializable(typeof(ApiResponse<PowerConfig>))]
+[JsonSerializable(typeof(DisplayConfig))]
+[JsonSerializable(typeof(ApiResponse<DisplayConfig>))]
 [JsonSerializable(typeof(UpdateResult))]
 [JsonSerializable(typeof(ApiResponse<UpdateResult>))]
 [JsonSerializable(typeof(RunningGameDiagnostics))]

--- a/src/HaPcRemote.Core/Configuration/PcRemoteOptions.cs
+++ b/src/HaPcRemote.Core/Configuration/PcRemoteOptions.cs
@@ -13,6 +13,9 @@ public sealed class PcRemoteOptions
     public PowerSettings Power { get; set; } = new();
     public SteamConfig Steam { get; set; } = new();
     public DisplaySwitchingMode DisplaySwitching { get; set; } = DisplaySwitchingMode.Compatible;
+
+    /// <summary>Base delay (ms) between mode-apply retries. Doubles each attempt. 0 = no retry.</summary>
+    public int DisplayActionDelayMs { get; set; } = 300;
 }
 
 public enum DisplaySwitchingMode

--- a/src/HaPcRemote.Core/Configuration/PcRemoteOptions.cs
+++ b/src/HaPcRemote.Core/Configuration/PcRemoteOptions.cs
@@ -13,6 +13,7 @@ public sealed class PcRemoteOptions
     public PowerSettings Power { get; set; } = new();
     public SteamConfig Steam { get; set; } = new();
     public DisplaySwitchingMode DisplaySwitching { get; set; } = DisplaySwitchingMode.Compatible;
+    public bool UseSavedLayout { get; set; } = true;
 
     /// <summary>Base delay (ms) between mode-apply retries. Doubles each attempt. 0 = no retry.</summary>
     public int DisplayActionDelayMs { get; set; } = 300;

--- a/src/HaPcRemote.Core/Endpoints/DisplayEndpoints.cs
+++ b/src/HaPcRemote.Core/Endpoints/DisplayEndpoints.cs
@@ -1,0 +1,31 @@
+using HaPcRemote.Service.Configuration;
+using HaPcRemote.Service.Middleware;
+using HaPcRemote.Service.Models;
+using HaPcRemote.Service.Services;
+using Microsoft.Extensions.Options;
+
+namespace HaPcRemote.Service.Endpoints;
+
+public static class DisplayEndpoints
+{
+    public static RouteGroupBuilder MapDisplayEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/system/display");
+        group.AddEndpointFilter<EndpointExceptionFilter>();
+
+        group.MapGet("/", (IOptionsMonitor<PcRemoteOptions> options) =>
+        {
+            return Results.Json(
+                ApiResponse.Ok(new DisplayConfig { DisplayActionDelayMs = options.CurrentValue.DisplayActionDelayMs }),
+                AppJsonContext.Default.ApiResponseDisplayConfig);
+        });
+
+        group.MapPut("/", (DisplayConfig body, IConfigurationWriter writer) =>
+        {
+            writer.SaveDisplayActionDelay(body.DisplayActionDelayMs);
+            return Results.Json(ApiResponse.Ok("Display settings saved"), AppJsonContext.Default.ApiResponse);
+        });
+
+        return group;
+    }
+}

--- a/src/HaPcRemote.Core/HostBootstrapExtensions.cs
+++ b/src/HaPcRemote.Core/HostBootstrapExtensions.cs
@@ -19,7 +19,9 @@ public static class HostBootstrapExtensions
                 options.ToolsPath = Path.GetFullPath(options.ToolsPath, baseDir);
             foreach (var app in options.Apps.Values)
             {
-                if (!string.IsNullOrEmpty(app.ExePath) && !Path.IsPathRooted(app.ExePath))
+                if (!string.IsNullOrEmpty(app.ExePath)
+                    && !Path.IsPathRooted(app.ExePath)
+                    && !DirectAppLauncher.IsProtocolUri(app.ExePath))
                     app.ExePath = Path.GetFullPath(app.ExePath, baseDir);
             }
         });

--- a/src/HaPcRemote.Core/Models/AudioDevice.cs
+++ b/src/HaPcRemote.Core/Models/AudioDevice.cs
@@ -5,4 +5,5 @@ public sealed class AudioDevice
     public required string Name { get; init; }
     public required int Volume { get; init; }
     public required bool IsDefault { get; init; }
+    public required bool IsConnected { get; init; }
 }

--- a/src/HaPcRemote.Core/Models/DisplayConfig.cs
+++ b/src/HaPcRemote.Core/Models/DisplayConfig.cs
@@ -1,0 +1,6 @@
+namespace HaPcRemote.Service.Models;
+
+public sealed class DisplayConfig
+{
+    public int DisplayActionDelayMs { get; init; }
+}

--- a/src/HaPcRemote.Core/Models/MonitorInfo.cs
+++ b/src/HaPcRemote.Core/Models/MonitorInfo.cs
@@ -11,5 +11,5 @@ public sealed class MonitorInfo
     public required int DisplayFrequency { get; init; }
     public required bool IsActive { get; init; }
     public required bool IsPrimary { get; init; }
-    public bool HasSavedLayout { get; set; }
+    public bool HasSavedLayout { get; init; }
 }

--- a/src/HaPcRemote.Core/Models/MonitorInfo.cs
+++ b/src/HaPcRemote.Core/Models/MonitorInfo.cs
@@ -11,4 +11,5 @@ public sealed class MonitorInfo
     public required int DisplayFrequency { get; init; }
     public required bool IsActive { get; init; }
     public required bool IsPrimary { get; init; }
+    public bool HasSavedLayout { get; set; }
 }

--- a/src/HaPcRemote.Core/Native/DisplayConfigHelper.cs
+++ b/src/HaPcRemote.Core/Native/DisplayConfigHelper.cs
@@ -18,14 +18,14 @@ internal sealed class DisplayConfigHelper(ILogger<DisplayConfigHelper> logger) :
         DISPLAYCONFIG_PATH_INFO[] paths;
         DISPLAYCONFIG_MODE_INFO[] modes;
 
-        logger.LogDebug("QueryConfig: flags={Flags}", flags);
+        logger.LogTrace("QueryConfig: flags={Flags}", flags);
 
         for (var attempt = 0; attempt < 3; attempt++)
         {
             status = GetDisplayConfigBufferSizes(flags, out var pathCount, out var modeCount);
             ThrowOnError(status, nameof(GetDisplayConfigBufferSizes));
 
-            logger.LogDebug("QueryConfig: buffers allocated — {Paths} paths, {Modes} modes", pathCount, modeCount);
+            logger.LogTrace("QueryConfig: buffers allocated — {Paths} paths, {Modes} modes", pathCount, modeCount);
 
             paths = new DISPLAYCONFIG_PATH_INFO[pathCount];
             modes = new DISPLAYCONFIG_MODE_INFO[modeCount];
@@ -34,7 +34,7 @@ internal sealed class DisplayConfigHelper(ILogger<DisplayConfigHelper> logger) :
 
             if (status == ERROR_INSUFFICIENT_BUFFER)
             {
-                logger.LogDebug("QueryConfig: buffer too small on attempt {Attempt}, retrying", attempt + 1);
+                logger.LogTrace("QueryConfig: buffer too small on attempt {Attempt}, retrying", attempt + 1);
                 continue;
             }
 
@@ -45,7 +45,7 @@ internal sealed class DisplayConfigHelper(ILogger<DisplayConfigHelper> logger) :
             if (modeCount < modes.Length)
                 Array.Resize(ref modes, modeCount);
 
-            logger.LogDebug("QueryConfig: returned {Paths} paths, {Modes} modes", paths.Length, modes.Length);
+            logger.LogTrace("QueryConfig: returned {Paths} paths, {Modes} modes", paths.Length, modes.Length);
             return (paths, modes);
         }
 
@@ -61,7 +61,7 @@ internal sealed class DisplayConfigHelper(ILogger<DisplayConfigHelper> logger) :
         {
             var p = paths[i];
             var active = (p.flags & DISPLAYCONFIG_PATH_FLAGS.ACTIVE) != 0;
-            logger.LogDebug(
+            logger.LogTrace(
                 "  Path[{I}]: adapter=({Lo},{Hi}) source={Src} target={Tgt} active={Active} srcMode={SrcIdx} tgtMode={TgtIdx}",
                 i, p.sourceInfo.adapterId.LowPart, p.sourceInfo.adapterId.HighPart,
                 p.sourceInfo.id, p.targetInfo.id, active,
@@ -73,14 +73,14 @@ internal sealed class DisplayConfigHelper(ILogger<DisplayConfigHelper> logger) :
             var m = modes[i];
             if (m.infoType == DISPLAYCONFIG_MODE_INFO_TYPE.SOURCE)
             {
-                logger.LogDebug(
+                logger.LogTrace(
                     "  Mode[{I}]: SOURCE {W}x{H} pos=({X},{Y})",
                     i, m.info.sourceMode.width, m.info.sourceMode.height,
                     m.info.sourceMode.position.x, m.info.sourceMode.position.y);
             }
             else if (m.infoType == DISPLAYCONFIG_MODE_INFO_TYPE.TARGET)
             {
-                logger.LogDebug(
+                logger.LogTrace(
                     "  Mode[{I}]: TARGET vSync={Hz}Hz",
                     i, m.info.targetMode.targetVideoSignalInfo.vSyncFreq.ToHz());
             }
@@ -103,7 +103,7 @@ internal sealed class DisplayConfigHelper(ILogger<DisplayConfigHelper> logger) :
 
         var friendly = deviceName.monitorFriendlyDeviceName ?? "";
         var path = deviceName.monitorDevicePath ?? "";
-        logger.LogDebug(
+        logger.LogTrace(
             "GetTargetDeviceInfo: target={TargetId} friendly=\"{Friendly}\" edid={Mfg:X4}:{Prod:X4} connector={Conn} devicePath=\"{Path}\"",
             targetId, friendly, deviceName.edidManufactureId, deviceName.edidProductCodeId,
             deviceName.connectorInstance, path);
@@ -123,7 +123,7 @@ internal sealed class DisplayConfigHelper(ILogger<DisplayConfigHelper> logger) :
         ThrowOnError(status, nameof(DisplayConfigGetDeviceInfo));
 
         var gdiName = sourceName.viewGdiDeviceName ?? "";
-        logger.LogDebug("GetSourceGdiName: source={SourceId} gdi=\"{GdiName}\"", sourceId, gdiName);
+        logger.LogTrace("GetSourceGdiName: source={SourceId} gdi=\"{GdiName}\"", sourceId, gdiName);
         return gdiName;
     }
 

--- a/src/HaPcRemote.Core/Services/AudioService.cs
+++ b/src/HaPcRemote.Core/Services/AudioService.cs
@@ -8,7 +8,7 @@ public class AudioService(IOptionsMonitor<PcRemoteOptions> options, ICliRunner c
 {
     public async Task<List<AudioDevice>> GetDevicesAsync()
     {
-        var output = await cliRunner.RunAsync(GetExePath(), ["/scomma", "", "/Columns", "Type,Name,Direction,Default,Volume Percent"]);
+        var output = await cliRunner.RunAsync(GetExePath(), ["/scomma", "", "/Columns", "Type,Name,Direction,Default,Volume Percent,Status"]);
         return ParseCsvOutput(output);
     }
 
@@ -54,7 +54,7 @@ public class AudioService(IOptionsMonitor<PcRemoteOptions> options, ICliRunner c
                 continue;
 
             // Columns selected via /Columns flag:
-            // [0] Type, [1] Name, [2] Direction, [3] Default (Console), [4] Volume Percent
+            // [0] Type, [1] Name, [2] Direction, [3] Default (Console), [4] Volume Percent, [5] Status
 
             // Only include hardware sound card devices; exclude Application/Subunit entries
             // (virtual audio devices created by apps, software mixers, etc.)
@@ -67,11 +67,13 @@ public class AudioService(IOptionsMonitor<PcRemoteOptions> options, ICliRunner c
             if (!seen.Add(columns[1]))
                 continue;
 
+            var status = columns.Count > 5 ? columns[5].Trim() : string.Empty;
             devices.Add(new AudioDevice
             {
                 Name = columns[1],
                 IsDefault = string.Equals(columns[3], "Render", StringComparison.OrdinalIgnoreCase),
-                Volume = ParseVolumePercent(columns[4])
+                Volume = ParseVolumePercent(columns[4]),
+                IsConnected = string.Equals(status, "Active", StringComparison.OrdinalIgnoreCase)
             });
         }
         return devices;

--- a/src/HaPcRemote.Core/Services/ConfigurationWriter.cs
+++ b/src/HaPcRemote.Core/Services/ConfigurationWriter.cs
@@ -65,6 +65,9 @@ public sealed class ConfigurationWriter(string configPath) : IConfigurationWrite
     public void SaveDisplaySwitching(DisplaySwitchingMode mode)
         => ModifyAndWrite(o => o.DisplaySwitching = mode);
 
+    public void SaveDisplayActionDelay(int delayMs)
+        => ModifyAndWrite(o => o.DisplayActionDelayMs = Math.Max(0, delayMs));
+
 
     private void ModifyAndWrite(Action<PcRemoteOptions> modifier)
     {

--- a/src/HaPcRemote.Core/Services/ConfigurationWriter.cs
+++ b/src/HaPcRemote.Core/Services/ConfigurationWriter.cs
@@ -68,6 +68,8 @@ public sealed class ConfigurationWriter(string configPath) : IConfigurationWrite
     public void SaveDisplayActionDelay(int delayMs)
         => ModifyAndWrite(o => o.DisplayActionDelayMs = Math.Max(0, delayMs));
 
+    public void SaveUseSavedLayout(bool useSavedLayout)
+        => ModifyAndWrite(o => o.UseSavedLayout = useSavedLayout);
 
     private void ModifyAndWrite(Action<PcRemoteOptions> modifier)
     {

--- a/src/HaPcRemote.Core/Services/IConfigurationWriter.cs
+++ b/src/HaPcRemote.Core/Services/IConfigurationWriter.cs
@@ -37,4 +37,7 @@ public interface IConfigurationWriter
 
     /// <summary>Update the display switching mode.</summary>
     void SaveDisplaySwitching(DisplaySwitchingMode mode);
+
+    /// <summary>Update the display action retry delay in milliseconds.</summary>
+    void SaveDisplayActionDelay(int delayMs);
 }

--- a/src/HaPcRemote.Core/Services/IConfigurationWriter.cs
+++ b/src/HaPcRemote.Core/Services/IConfigurationWriter.cs
@@ -40,4 +40,7 @@ public interface IConfigurationWriter
 
     /// <summary>Update the display action retry delay in milliseconds.</summary>
     void SaveDisplayActionDelay(int delayMs);
+
+    /// <summary>Update the saved display layout toggle.</summary>
+    void SaveUseSavedLayout(bool useSavedLayout);
 }

--- a/src/HaPcRemote.Core/Services/LinuxAudioService.cs
+++ b/src/HaPcRemote.Core/Services/LinuxAudioService.cs
@@ -78,7 +78,8 @@ public sealed class LinuxAudioService(ICliRunner cliRunner, ILogger<LinuxAudioSe
             {
                 Name = name,
                 IsDefault = isDefault,
-                Volume = 0 // pactl list sinks short does not include volume; would need verbose output
+                Volume = 0, // pactl list sinks short does not include volume; would need verbose output
+                IsConnected = true // pactl only reports active (running/idle/suspended) sinks
             });
         }
         return devices;

--- a/src/HaPcRemote.Core/Services/LinuxMonitorService.cs
+++ b/src/HaPcRemote.Core/Services/LinuxMonitorService.cs
@@ -43,7 +43,7 @@ public sealed partial class LinuxMonitorService(
 
         if (monitor.IsActive)
         {
-            logger.LogInformation("Monitor '{Id}' is already enabled, skipping", id);
+            logger.LogDebug("Monitor '{Id}' is already enabled, skipping", id);
             return;
         }
 
@@ -57,7 +57,7 @@ public sealed partial class LinuxMonitorService(
 
         if (!monitor.IsActive)
         {
-            logger.LogInformation("Monitor '{Id}' is already disabled, skipping", id);
+            logger.LogDebug("Monitor '{Id}' is already disabled, skipping", id);
             return;
         }
 

--- a/src/HaPcRemote.Core/Services/ModeService.cs
+++ b/src/HaPcRemote.Core/Services/ModeService.cs
@@ -11,6 +11,8 @@ public sealed class ModeService(
     IAppService appService,
     ILogger<ModeService> logger) : IModeService
 {
+    private const int MaxRetries = 4;
+
     public IReadOnlyList<string> GetModeNames() =>
         options.CurrentValue.Modes.Keys.ToList();
 
@@ -20,6 +22,35 @@ public sealed class ModeService(
         if (!modes.TryGetValue(modeName, out var config))
             throw new KeyNotFoundException($"Mode '{modeName}' not found.");
 
+        var baseDelay = options.CurrentValue.DisplayActionDelayMs;
+        if (baseDelay <= 0)
+        {
+            await ApplyModeCoreAsync(config);
+            return;
+        }
+
+        for (var attempt = 0; attempt <= MaxRetries; attempt++)
+        {
+            try
+            {
+                await ApplyModeCoreAsync(config);
+                if (attempt > 0)
+                    logger.LogInformation("Mode '{Mode}' applied on attempt {Attempt}", modeName, attempt + 1);
+                return;
+            }
+            catch (Exception ex) when (attempt < MaxRetries)
+            {
+                var delay = baseDelay * (1 << attempt);
+                logger.LogWarning(
+                    "Mode '{Mode}' failed on attempt {Attempt}/{Max}, retrying in {Delay}ms: {Error}",
+                    modeName, attempt + 1, MaxRetries + 1, delay, ex.Message);
+                await Task.Delay(delay);
+            }
+        }
+    }
+
+    private async Task ApplyModeCoreAsync(ModeConfig config)
+    {
         // Monitor first — audio devices may only appear after the monitor is active
         if (config.SoloMonitor is not null)
             await monitorService.SoloMonitorAsync(config.SoloMonitor);

--- a/src/HaPcRemote.Core/Services/ModeService.cs
+++ b/src/HaPcRemote.Core/Services/ModeService.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using HaPcRemote.Service.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -38,7 +39,7 @@ public sealed class ModeService(
                     logger.LogInformation("Mode '{Mode}' applied on attempt {Attempt}", modeName, attempt + 1);
                 return;
             }
-            catch (Exception ex) when (attempt < MaxRetries)
+            catch (Exception ex) when (attempt < MaxRetries && IsTransientError(ex))
             {
                 var delay = baseDelay * (1 << attempt);
                 logger.LogWarning(
@@ -48,6 +49,14 @@ public sealed class ModeService(
             }
         }
     }
+
+    /// <summary>
+    /// Returns true for transient errors worth retrying at the mode level.
+    /// Error 87 (ERROR_INVALID_PARAMETER) is a configuration error — WindowsMonitorService
+    /// already retries internally. If it still fails, retrying at this level won't help. (#119)
+    /// </summary>
+    private static bool IsTransientError(Exception ex) =>
+        ex is not Win32Exception { NativeErrorCode: 87 /* ERROR_INVALID_PARAMETER */ };
 
     private async Task ApplyModeCoreAsync(ModeConfig config)
     {

--- a/src/HaPcRemote.Core/Services/SteamArtworkService.cs
+++ b/src/HaPcRemote.Core/Services/SteamArtworkService.cs
@@ -22,7 +22,7 @@ internal static class SteamArtworkService
     {
         // For non-Steam shortcuts, use unsigned representation for filenames
         var fileId = SteamVdfParser.IsShortcutAppId(appId) ? ((uint)appId).ToString() : appId.ToString();
-        logger?.LogInformation("Artwork: lookup appId={AppId} fileId={FileId} isShortcut={IsShortcut}",
+        logger?.LogDebug("Artwork: lookup appId={AppId} fileId={FileId} isShortcut={IsShortcut}",
             appId, fileId, SteamVdfParser.IsShortcutAppId(appId));
 
         // Priority 1: Custom grid art (user-set posters)
@@ -41,7 +41,7 @@ internal static class SteamArtworkService
                         return path;
                     }
                 }
-                logger?.LogInformation("Artwork: not found in custom grid {GridDir}", gridDir);
+                logger?.LogDebug("Artwork: not found in custom grid {GridDir}", gridDir);
             }
             else
             {
@@ -50,7 +50,7 @@ internal static class SteamArtworkService
         }
         else
         {
-            logger?.LogInformation("Artwork: no steamUserId, skipping custom grid lookup");
+            logger?.LogDebug("Artwork: no steamUserId, skipping custom grid lookup");
         }
 
         // Priority 2: Steam local library cache (multiple filename variants)
@@ -72,7 +72,7 @@ internal static class SteamArtworkService
                     }
                 }
             }
-            logger?.LogInformation("Artwork: not found in library cache {CacheDir} (checked {Count} suffix variants)",
+            logger?.LogDebug("Artwork: not found in library cache {CacheDir} (checked {Count} suffix variants)",
                 cacheDir, libraryCacheSuffixes.Length);
         }
         else

--- a/src/HaPcRemote.Core/Services/SteamService.cs
+++ b/src/HaPcRemote.Core/Services/SteamService.cs
@@ -17,7 +17,7 @@ public sealed class SteamService(
     private readonly Func<int, Task> _delay = delay ?? (ms => Task.Delay(ms));
     private List<SteamGame>? _cachedGames;
     private DateTime _cacheExpiry;
-    private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
     private readonly SemaphoreSlim _cacheLock = new(1, 1);
     private IReadOnlyList<string>? _libraryFolders;
 

--- a/src/HaPcRemote.Core/Services/UpdateService.cs
+++ b/src/HaPcRemote.Core/Services/UpdateService.cs
@@ -63,7 +63,7 @@ public sealed class UpdateService(IHttpClientFactory httpClientFactory, ILogger<
 
         var release = await CheckForUpdateAsync(currentVersion, prerelease, ct);
         if (release is null)
-            logger.LogInformation("No update found — already up to date at {CurrentVersion}", currentVersionStr);
+            logger.LogDebug("No update found — already up to date at {CurrentVersion}", currentVersionStr);
         return release;
     }
 

--- a/src/HaPcRemote.Core/Services/UpdateService.cs
+++ b/src/HaPcRemote.Core/Services/UpdateService.cs
@@ -182,10 +182,13 @@ public sealed class UpdateService(IHttpClientFactory httpClientFactory, ILogger<
         if (dashIdx >= 0)
         {
             var suffix = cleaned[(dashIdx + 1)..];
-            // Extract trailing number from prerelease suffix (e.g. "rc.3" → 3, "beta.1" → 1)
+            // Extract trailing number from prerelease suffix
+            // Handles both "rc.3" (dot-separated) and "rc3" (concatenated) formats
             var dotIdx = suffix.LastIndexOf('.');
             if (dotIdx >= 0 && int.TryParse(suffix[(dotIdx + 1)..], out var n))
                 prerelease = n;
+            else if (TrailingDigits(suffix) is { } digits && int.TryParse(digits, out var m))
+                prerelease = m;
             else
                 prerelease = 0; // e.g. "beta" with no number
 
@@ -206,6 +209,13 @@ public sealed class UpdateService(IHttpClientFactory httpClientFactory, ILogger<
         v.Revision == int.MaxValue
             ? v.ToString(3)
             : $"{v.Major}.{v.Minor}.{v.Build}-rc.{v.Revision}";
+
+    private static string? TrailingDigits(string s)
+    {
+        var i = s.Length;
+        while (i > 0 && char.IsAsciiDigit(s[i - 1])) i--;
+        return i < s.Length ? s[i..] : null;
+    }
 
     private HttpClient CreateHttpClient()
     {

--- a/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
@@ -249,18 +249,26 @@ internal sealed class WindowsMonitorService : IMonitorService
     private (DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes) BuildEnableConfig(
         (LUID adapterId, uint targetId) targetKey)
     {
-        // TODO #121: Re-enable QDC_DATABASE_CURRENT with UI toggle
-        // Currently disabled — causes error 87 on SetDisplayConfig when no saved layout exists
-        // try
-        // {
-        //     config = _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT);
-        // }
-        // catch (Win32Exception ex) when (ex.NativeErrorCode == ERROR_INVALID_PARAMETER)
-        // {
-        //     _logger.LogDebug("QDC_DATABASE_CURRENT unavailable, falling back to QDC_ALL_PATHS");
-        //     config = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
-        // }
-        var (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
+        DISPLAYCONFIG_PATH_INFO[] paths;
+        DISPLAYCONFIG_MODE_INFO[] modes;
+
+        if (_options.CurrentValue.UseSavedLayout)
+        {
+            try
+            {
+                (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT);
+            }
+            catch (Win32Exception ex) when (ex.NativeErrorCode == ERROR_INVALID_PARAMETER)
+            {
+                _logger.LogDebug("QDC_DATABASE_CURRENT unavailable, falling back to QDC_ALL_PATHS");
+                (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
+            }
+        }
+        else
+        {
+            (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
+        }
+
         var idx = FindPathIndex(paths, targetKey);
         paths[idx].flags |= DISPLAYCONFIG_PATH_FLAGS.ACTIVE;
         paths[idx].sourceInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;

--- a/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
@@ -201,7 +201,8 @@ internal sealed class WindowsMonitorService : IMonitorService
         _logger.LogInformation("Enabling monitor: {Name} ({Id})", target.MonitorName, target.MonitorId);
 
         var targetKey = ResolveTargetKey(target);
-        ApplyWithRetry(() => BuildEnableConfig(targetKey), SetDisplayConfigFlags.SDC_TOPOLOGY_EXTEND);
+        // TODO #121: SDC_TOPOLOGY_EXTEND removed — causes error 87 with SDC_USE_SUPPLIED_DISPLAY_CONFIG. Investigate proper topology handling.
+        ApplyWithRetry(() => BuildEnableConfig(targetKey));
         InvalidateCache();
     }
 
@@ -455,11 +456,11 @@ internal sealed class WindowsMonitorService : IMonitorService
         _logger.LogInformation("Enabling monitor (compatible): {Name} ({Id})", target.MonitorName, target.MonitorId);
 
         var targetKey = ResolveTargetKey(target);
+        // TODO #121: SDC_TOPOLOGY_EXTEND removed — causes error 87 with SDC_USE_SUPPLIED_DISPLAY_CONFIG. Investigate proper topology handling.
         await ApplyStepWithVerification(
             () => BuildEnableConfig(targetKey),
             () => FindMonitor(QueryMonitors(), id).IsActive,
-            $"Enable({id})",
-            SetDisplayConfigFlags.SDC_TOPOLOGY_EXTEND);
+            $"Enable({id})");
     }
 
     private async Task SetPrimaryCompatibleAsync(string id)

--- a/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
@@ -197,7 +197,7 @@ internal sealed class WindowsMonitorService : IMonitorService
         _logger.LogInformation("Enabling monitor: {Name} ({Id})", target.MonitorName, target.MonitorId);
 
         var targetKey = ResolveTargetKey(target);
-        ApplyWithRetry(() => BuildEnableConfig(targetKey));
+        ApplyWithRetry(() => BuildEnableConfig(targetKey), SetDisplayConfigFlags.SDC_TOPOLOGY_EXTEND);
         InvalidateCache();
     }
 
@@ -244,7 +244,7 @@ internal sealed class WindowsMonitorService : IMonitorService
     private (DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes) BuildEnableConfig(
         (LUID adapterId, uint targetId) targetKey)
     {
-        var (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
+        var (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT);
         var idx = FindPathIndex(paths, targetKey);
         paths[idx].flags |= DISPLAYCONFIG_PATH_FLAGS.ACTIVE;
         paths[idx].sourceInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
@@ -443,7 +443,8 @@ internal sealed class WindowsMonitorService : IMonitorService
         await ApplyStepWithVerification(
             () => BuildEnableConfig(targetKey),
             () => FindMonitor(QueryMonitors(), id).IsActive,
-            $"Enable({id})");
+            $"Enable({id})",
+            SetDisplayConfigFlags.SDC_TOPOLOGY_EXTEND);
     }
 
     private async Task SetPrimaryCompatibleAsync(string id)
@@ -508,11 +509,12 @@ internal sealed class WindowsMonitorService : IMonitorService
     private async Task ApplyStepWithVerification(
         Func<(DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes)> buildConfig,
         Func<bool> verify,
-        string stepName)
+        string stepName,
+        SetDisplayConfigFlags extraFlags = 0)
     {
         for (var attempt = 0; attempt < MaxVerifyAttempts; attempt++)
         {
-            ApplyWithRetry(buildConfig);
+            ApplyWithRetry(buildConfig, extraFlags);
             InvalidateCache();
 
             if (attempt > 0 && StepDelayMs > 0)
@@ -556,13 +558,15 @@ internal sealed class WindowsMonitorService : IMonitorService
     /// Error 87 (INVALID_PARAMETER): stale adapter LUIDs — re-query and rebuild config via <paramref name="buildConfig"/>.
     /// </summary>
     private void ApplyWithRetry(
-        Func<(DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes)> buildConfig)
+        Func<(DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes)> buildConfig,
+        SetDisplayConfigFlags extraFlags = 0)
     {
-        const SetDisplayConfigFlags flags =
+        var flags =
             SetDisplayConfigFlags.SDC_APPLY
             | SetDisplayConfigFlags.SDC_USE_SUPPLIED_DISPLAY_CONFIG
             | SetDisplayConfigFlags.SDC_ALLOW_CHANGES
-            | SetDisplayConfigFlags.SDC_SAVE_TO_DATABASE;
+            | SetDisplayConfigFlags.SDC_SAVE_TO_DATABASE
+            | extraFlags;
 
         var (paths, modes) = buildConfig();
 

--- a/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
@@ -248,18 +248,18 @@ internal sealed class WindowsMonitorService : IMonitorService
     private (DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes) BuildEnableConfig(
         (LUID adapterId, uint targetId) targetKey)
     {
-        (DISPLAYCONFIG_PATH_INFO[] paths, DISPLAYCONFIG_MODE_INFO[] modes) config;
-        try
-        {
-            config = _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT);
-        }
-        catch (Win32Exception ex) when (ex.NativeErrorCode == ERROR_INVALID_PARAMETER)
-        {
-            _logger.LogDebug("QDC_DATABASE_CURRENT unavailable, falling back to QDC_ALL_PATHS");
-            config = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
-        }
-
-        var (paths, modes) = config;
+        // TODO #121: Re-enable QDC_DATABASE_CURRENT with UI toggle
+        // Currently disabled — causes error 87 on SetDisplayConfig when no saved layout exists
+        // try
+        // {
+        //     config = _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT);
+        // }
+        // catch (Win32Exception ex) when (ex.NativeErrorCode == ERROR_INVALID_PARAMETER)
+        // {
+        //     _logger.LogDebug("QDC_DATABASE_CURRENT unavailable, falling back to QDC_ALL_PATHS");
+        //     config = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
+        // }
+        var (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
         var idx = FindPathIndex(paths, targetKey);
         paths[idx].flags |= DISPLAYCONFIG_PATH_FLAGS.ACTIVE;
         paths[idx].sourceInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;

--- a/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
@@ -60,6 +60,7 @@ internal sealed class WindowsMonitorService : IMonitorService
     {
         _logger.LogDebug("QueryMonitors: starting enumeration");
         var (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
+        var savedKeys = ProbeSavedLayoutKeys();
         var monitors = new List<MonitorInfo>();
         var seen = new HashSet<(LUID adapterId, uint targetId)>();
         var edidCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
@@ -171,6 +172,7 @@ internal sealed class WindowsMonitorService : IMonitorService
                 DisplayFrequency = hz,
                 IsActive = isActive,
                 IsPrimary = isPrimary,
+                HasSavedLayout = savedKeys.Contains(key),
             });
         }
 
@@ -179,8 +181,6 @@ internal sealed class WindowsMonitorService : IMonitorService
         foreach (var m in monitors)
             _logger.LogDebug("  {Id}: \"{Name}\" ({Gdi}) {W}x{H}@{Hz}Hz active={Active} primary={Primary}",
                 m.MonitorId, m.MonitorName, m.Name, m.Width, m.Height, m.DisplayFrequency, m.IsActive, m.IsPrimary);
-
-        ProbeSavedLayouts(monitors);
 
         return monitors;
     }
@@ -570,21 +570,13 @@ internal sealed class WindowsMonitorService : IMonitorService
 
     // ── Saved layout probe ─────────────────────────────────────────────
 
-    private void ProbeSavedLayouts(List<MonitorInfo> monitors)
+    private HashSet<(LUID adapterId, uint targetId)> ProbeSavedLayoutKeys()
     {
         try
         {
             var (dbPaths, _) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT);
-            var savedKeys = new HashSet<(LUID adapterId, uint targetId)>(
+            return new HashSet<(LUID adapterId, uint targetId)>(
                 dbPaths.Select(p => (p.targetInfo.adapterId, p.targetInfo.id)));
-
-            for (var i = 0; i < monitors.Count; i++)
-            {
-                if (!_targetKeys.TryGetValue(monitors[i].MonitorId, out var key))
-                    continue;
-                if (savedKeys.Contains(key))
-                    monitors[i].HasSavedLayout = true;
-            }
         }
         catch (Win32Exception ex) when (ex.NativeErrorCode == ERROR_INVALID_PARAMETER)
         {
@@ -592,8 +584,10 @@ internal sealed class WindowsMonitorService : IMonitorService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "ProbeSavedLayouts: unexpected error, HasSavedLayout will be false");
+            _logger.LogWarning(ex, "ProbeSavedLayoutKeys: unexpected error, HasSavedLayout will be false");
         }
+
+        return [];
     }
 
     // ── Helpers ────────────────────────────────────────────────────────

--- a/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
@@ -248,33 +248,44 @@ internal sealed class WindowsMonitorService : IMonitorService
         InvalidateCache();
     }
 
-    private (DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes) BuildEnableConfig(
-        (LUID adapterId, uint targetId) targetKey)
+    private (DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes, bool UsedDatabase)
+        QueryConfigWithFallback((LUID adapterId, uint targetId) requiredTarget)
     {
-        DISPLAYCONFIG_PATH_INFO[] paths;
-        DISPLAYCONFIG_MODE_INFO[] modes;
-
         if (_options.CurrentValue.UseSavedLayout)
         {
             try
             {
-                (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT);
+                var (dbPaths, dbModes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT);
+                if (ContainsTarget(dbPaths, requiredTarget))
+                    return (dbPaths, dbModes, true);
+
+                _logger.LogDebug("Target not in QDC_DATABASE_CURRENT result, falling back to QDC_ALL_PATHS");
             }
             catch (Win32Exception ex) when (ex.NativeErrorCode == ERROR_INVALID_PARAMETER)
             {
                 _logger.LogDebug("QDC_DATABASE_CURRENT unavailable, falling back to QDC_ALL_PATHS");
-                (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
             }
         }
-        else
-        {
-            (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
-        }
+
+        var (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
+        return (paths, modes, false);
+    }
+
+    private static bool ContainsTarget(DISPLAYCONFIG_PATH_INFO[] paths, (LUID adapterId, uint targetId) key) =>
+        Array.Exists(paths, p => p.targetInfo.adapterId == key.adapterId && p.targetInfo.id == key.targetId);
+
+    private (DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes) BuildEnableConfig(
+        (LUID adapterId, uint targetId) targetKey)
+    {
+        var (paths, modes, usedDatabase) = QueryConfigWithFallback(targetKey);
 
         var idx = FindPathIndex(paths, targetKey);
         paths[idx].flags |= DISPLAYCONFIG_PATH_FLAGS.ACTIVE;
-        paths[idx].sourceInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
-        paths[idx].targetInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+        if (!usedDatabase)
+        {
+            paths[idx].sourceInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+            paths[idx].targetInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+        }
         return (paths, modes);
     }
 
@@ -368,7 +379,7 @@ internal sealed class WindowsMonitorService : IMonitorService
     private (DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes) BuildSoloConfig(
         (LUID adapterId, uint targetId) targetKey, string monitorId)
     {
-        var (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
+        var (paths, modes, usedDatabase) = QueryConfigWithFallback(targetKey);
 
         var activeCount = 0;
         var inactiveCount = 0;
@@ -381,8 +392,11 @@ internal sealed class WindowsMonitorService : IMonitorService
             if (isTarget)
             {
                 paths[i].flags |= DISPLAYCONFIG_PATH_FLAGS.ACTIVE;
-                paths[i].sourceInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
-                paths[i].targetInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+                if (!usedDatabase)
+                {
+                    paths[i].sourceInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+                    paths[i].targetInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+                }
                 activeCount++;
             }
             else

--- a/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
@@ -171,7 +171,7 @@ internal sealed class WindowsMonitorService : IMonitorService
             });
         }
 
-        _logger.LogInformation("QueryMonitors: found {Count} monitors", monitors.Count);
+        _logger.LogDebug("QueryMonitors: found {Count} monitors", monitors.Count);
         foreach (var m in monitors)
             _logger.LogDebug("  {Id}: \"{Name}\" ({Gdi}) {W}x{H}@{Hz}Hz active={Active} primary={Primary}",
                 m.MonitorId, m.MonitorName, m.Name, m.Width, m.Height, m.DisplayFrequency, m.IsActive, m.IsPrimary);
@@ -190,7 +190,7 @@ internal sealed class WindowsMonitorService : IMonitorService
 
         if (target.IsActive)
         {
-            _logger.LogInformation("Monitor '{Id}' is already enabled, skipping", id);
+            _logger.LogDebug("Monitor '{Id}' is already enabled, skipping", id);
             return;
         }
 
@@ -210,7 +210,7 @@ internal sealed class WindowsMonitorService : IMonitorService
 
         if (!target.IsActive)
         {
-            _logger.LogInformation("Monitor '{Id}' is already disabled, skipping", id);
+            _logger.LogDebug("Monitor '{Id}' is already disabled, skipping", id);
             return;
         }
 
@@ -433,7 +433,7 @@ internal sealed class WindowsMonitorService : IMonitorService
 
         if (target.IsActive)
         {
-            _logger.LogInformation("Monitor '{Id}' is already enabled, skipping (compatible)", id);
+            _logger.LogDebug("Monitor '{Id}' is already enabled, skipping (compatible)", id);
             return;
         }
 
@@ -482,7 +482,7 @@ internal sealed class WindowsMonitorService : IMonitorService
 
         if (!target.IsActive)
         {
-            _logger.LogInformation("Monitor '{Id}' is already disabled, skipping (compatible)", id);
+            _logger.LogDebug("Monitor '{Id}' is already disabled, skipping (compatible)", id);
             return;
         }
 

--- a/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
@@ -68,11 +68,14 @@ internal sealed class WindowsMonitorService : IMonitorService
 
         _logger.LogDebug("QueryMonitors: processing {Count} paths", paths.Length);
 
+        var unavailableCount = 0;
+        var duplicateCount = 0;
+
         foreach (var path in paths)
         {
             if (path.targetInfo.targetAvailable == 0)
             {
-                _logger.LogDebug("  Skipping unavailable target {TargetId}", path.targetInfo.id);
+                unavailableCount++;
                 continue;
             }
 
@@ -97,7 +100,7 @@ internal sealed class WindowsMonitorService : IMonitorService
                 }
                 else
                 {
-                    _logger.LogDebug("  Skipping duplicate target {TargetId} (active={Active})", path.targetInfo.id, isActive);
+                    duplicateCount++;
                     continue;
                 }
             }
@@ -171,6 +174,7 @@ internal sealed class WindowsMonitorService : IMonitorService
             });
         }
 
+        _logger.LogDebug("QueryMonitors: skipped {Unavailable} unavailable and {Duplicate} duplicate paths", unavailableCount, duplicateCount);
         _logger.LogDebug("QueryMonitors: found {Count} monitors", monitors.Count);
         foreach (var m in monitors)
             _logger.LogDebug("  {Id}: \"{Name}\" ({Gdi}) {W}x{H}@{Hz}Hz active={Active} primary={Primary}",
@@ -244,7 +248,18 @@ internal sealed class WindowsMonitorService : IMonitorService
     private (DISPLAYCONFIG_PATH_INFO[] Paths, DISPLAYCONFIG_MODE_INFO[] Modes) BuildEnableConfig(
         (LUID adapterId, uint targetId) targetKey)
     {
-        var (paths, modes) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT);
+        (DISPLAYCONFIG_PATH_INFO[] paths, DISPLAYCONFIG_MODE_INFO[] modes) config;
+        try
+        {
+            config = _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT);
+        }
+        catch (Win32Exception ex) when (ex.NativeErrorCode == ERROR_INVALID_PARAMETER)
+        {
+            _logger.LogDebug("QDC_DATABASE_CURRENT unavailable, falling back to QDC_ALL_PATHS");
+            config = _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS);
+        }
+
+        var (paths, modes) = config;
         var idx = FindPathIndex(paths, targetKey);
         paths[idx].flags |= DISPLAYCONFIG_PATH_FLAGS.ACTIVE;
         paths[idx].sourceInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;

--- a/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
+++ b/src/HaPcRemote.Core/Services/WindowsMonitorService.cs
@@ -180,6 +180,8 @@ internal sealed class WindowsMonitorService : IMonitorService
             _logger.LogDebug("  {Id}: \"{Name}\" ({Gdi}) {W}x{H}@{Hz}Hz active={Active} primary={Primary}",
                 m.MonitorId, m.MonitorName, m.Name, m.Width, m.Height, m.DisplayFrequency, m.IsActive, m.IsPrimary);
 
+        ProbeSavedLayouts(monitors);
+
         return monitors;
     }
 
@@ -564,6 +566,34 @@ internal sealed class WindowsMonitorService : IMonitorService
     {
         InvalidateCache();
         return QueryMonitors();
+    }
+
+    // ── Saved layout probe ─────────────────────────────────────────────
+
+    private void ProbeSavedLayouts(List<MonitorInfo> monitors)
+    {
+        try
+        {
+            var (dbPaths, _) = _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT);
+            var savedKeys = new HashSet<(LUID adapterId, uint targetId)>(
+                dbPaths.Select(p => (p.targetInfo.adapterId, p.targetInfo.id)));
+
+            for (var i = 0; i < monitors.Count; i++)
+            {
+                if (!_targetKeys.TryGetValue(monitors[i].MonitorId, out var key))
+                    continue;
+                if (savedKeys.Contains(key))
+                    monitors[i].HasSavedLayout = true;
+            }
+        }
+        catch (Win32Exception ex) when (ex.NativeErrorCode == ERROR_INVALID_PARAMETER)
+        {
+            _logger.LogDebug("QDC_DATABASE_CURRENT unavailable — no saved layouts");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "ProbeSavedLayouts: unexpected error, HasSavedLayout will be false");
+        }
     }
 
     // ── Helpers ────────────────────────────────────────────────────────

--- a/src/HaPcRemote.Headless/Program.cs
+++ b/src/HaPcRemote.Headless/Program.cs
@@ -13,6 +13,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Logging — console (captured by journalctl) + file
 builder.Logging.ClearProviders();
+builder.Logging.SetMinimumLevel(LogLevel.Trace); // pass everything through; custom providers filter by their own MinimumLevel
 builder.Logging.AddFilter("Microsoft.AspNetCore", LogLevel.Warning);
 builder.Logging.AddConsole();
 builder.Logging.AddProvider(new FileLoggerProvider(ConfigPaths.GetLogFilePath()));

--- a/src/HaPcRemote.Tray/Forms/DiagnosticsTab.cs
+++ b/src/HaPcRemote.Tray/Forms/DiagnosticsTab.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using HaPcRemote.Service.Native;
 using HaPcRemote.Service.Services;
 using static HaPcRemote.Service.Native.DisplayConfigApi;
@@ -121,9 +122,9 @@ internal sealed class DiagnosticsTab : TabPage, ISettingsTab
 
             sb.AppendLine();
         }
-        catch (Exception ex) when (ex.Message.Contains("87") || ex.Message.Contains("invalid parameter", StringComparison.OrdinalIgnoreCase))
+        catch (Win32Exception ex) when (ex.NativeErrorCode == ERROR_INVALID_PARAMETER)
         {
-            sb.AppendLine("  unavailable (error 87 — not supported in this configuration)");
+            sb.AppendLine("  unavailable (error 87 — no saved layout in this configuration)");
             sb.AppendLine();
         }
         catch (Exception ex)

--- a/src/HaPcRemote.Tray/Forms/DiagnosticsTab.cs
+++ b/src/HaPcRemote.Tray/Forms/DiagnosticsTab.cs
@@ -1,0 +1,135 @@
+using HaPcRemote.Service.Native;
+using HaPcRemote.Service.Services;
+using static HaPcRemote.Service.Native.DisplayConfigApi;
+
+namespace HaPcRemote.Tray.Forms;
+
+internal sealed class DiagnosticsTab : TabPage, ISettingsTab
+{
+    private readonly IMonitorService _monitorService;
+    private readonly IDisplayConfigApi _displayConfigApi;
+    private readonly TextBox _outputBox;
+
+    public DiagnosticsTab(IServiceProvider services)
+    {
+        Text = "Diagnostics";
+        BackColor = Color.FromArgb(30, 30, 30);
+        ForeColor = Color.White;
+
+        _monitorService = services.GetRequiredService<IMonitorService>();
+        _displayConfigApi = services.GetRequiredService<IDisplayConfigApi>();
+
+        _outputBox = new TextBox
+        {
+            ReadOnly = true,
+            Multiline = true,
+            ScrollBars = ScrollBars.Vertical,
+            BackColor = Color.FromArgb(20, 20, 20),
+            ForeColor = Color.White,
+            Font = new Font("Consolas", 9f),
+            Dock = DockStyle.Fill,
+            BorderStyle = BorderStyle.None,
+            WordWrap = false
+        };
+
+        Controls.Add(_outputBox);
+    }
+
+    public IEnumerable<Button> CreateFooterButtons()
+    {
+        var refreshButton = TabFooter.MakeButton("Refresh");
+        refreshButton.Click += (_, _) => _ = LoadDataAsync();
+        return [refreshButton];
+    }
+
+    protected override void OnVisibleChanged(EventArgs e)
+    {
+        base.OnVisibleChanged(e);
+        if (Visible) _ = LoadDataAsync();
+    }
+
+    private async Task LoadDataAsync()
+    {
+        _outputBox.Text = "Loading...";
+
+        var sb = new System.Text.StringBuilder();
+
+        // Monitors from IMonitorService
+        sb.AppendLine("=== Monitors (IMonitorService.GetMonitorsAsync) ===");
+        try
+        {
+            var monitors = await _monitorService.GetMonitorsAsync();
+            if (monitors.Count == 0)
+            {
+                sb.AppendLine("  (none)");
+            }
+            else
+            {
+                foreach (var m in monitors)
+                {
+                    sb.AppendLine($"  Name:         {m.Name}");
+                    sb.AppendLine($"  MonitorId:    {m.MonitorId}");
+                    sb.AppendLine($"  MonitorName:  {m.MonitorName}");
+                    if (m.SerialNumber is not null)
+                        sb.AppendLine($"  SerialNumber: {m.SerialNumber}");
+                    sb.AppendLine($"  Resolution:   {m.Width}x{m.Height} @ {m.DisplayFrequency}Hz");
+                    sb.AppendLine($"  Active:       {m.IsActive}");
+                    sb.AppendLine($"  Primary:      {m.IsPrimary}");
+                    sb.AppendLine($"  SavedLayout:  {m.HasSavedLayout}");
+                    sb.AppendLine();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            sb.AppendLine($"  ERROR: {ex.Message}");
+            sb.AppendLine();
+        }
+
+        // QDC_ONLY_ACTIVE_PATHS
+        sb.AppendLine("=== QDC_ONLY_ACTIVE_PATHS ===");
+        AppendQueryResult(sb, QueryDisplayConfigFlags.QDC_ONLY_ACTIVE_PATHS, detailed: true);
+
+        // QDC_ALL_PATHS
+        sb.AppendLine("=== QDC_ALL_PATHS ===");
+        AppendQueryResult(sb, QueryDisplayConfigFlags.QDC_ALL_PATHS, detailed: false);
+
+        // QDC_DATABASE_CURRENT
+        sb.AppendLine("=== QDC_DATABASE_CURRENT ===");
+        AppendQueryResult(sb, QueryDisplayConfigFlags.QDC_DATABASE_CURRENT, detailed: false);
+
+        _outputBox.Text = sb.ToString();
+    }
+
+    private void AppendQueryResult(System.Text.StringBuilder sb, QueryDisplayConfigFlags flags, bool detailed)
+    {
+        try
+        {
+            var (paths, modes) = _displayConfigApi.QueryConfig(flags);
+            sb.AppendLine($"  Paths: {paths.Length}  Modes: {modes.Length}");
+
+            if (detailed)
+            {
+                for (int i = 0; i < paths.Length; i++)
+                {
+                    var p = paths[i];
+                    sb.AppendLine($"  [{i}] Source={p.sourceInfo.id}  Target={p.targetInfo.id}  " +
+                                  $"AdapterLuid={p.sourceInfo.adapterId.HighPart:X8}{p.sourceInfo.adapterId.LowPart:X8}  " +
+                                  $"Flags={p.flags}");
+                }
+            }
+
+            sb.AppendLine();
+        }
+        catch (Exception ex) when (ex.Message.Contains("87") || ex.Message.Contains("invalid parameter", StringComparison.OrdinalIgnoreCase))
+        {
+            sb.AppendLine("  unavailable (error 87 — not supported in this configuration)");
+            sb.AppendLine();
+        }
+        catch (Exception ex)
+        {
+            sb.AppendLine($"  ERROR: {ex.Message}");
+            sb.AppendLine();
+        }
+    }
+}

--- a/src/HaPcRemote.Tray/Forms/GeneralTab.cs
+++ b/src/HaPcRemote.Tray/Forms/GeneralTab.cs
@@ -20,6 +20,7 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
     private readonly Button _portSaveButton;
     private readonly Label _soundVolumeViewLabel;
     private readonly ComboBox _displaySwitchingCombo;
+    private readonly NumericUpDown _displayDelayInput;
     private readonly IConfigurationWriter _configWriter;
     private readonly int _currentPort;
 
@@ -111,6 +112,26 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
             "Compatible: sequential steps with verification (use if Direct fails)"));
         layout.Controls.Add(MakeLabel("Display Switching:"), 0, row);
         layout.Controls.Add(displaySwitchingPanel, 1, row++);
+
+        // Display action retry delay
+        _displayDelayInput = new NumericUpDown
+        {
+            Minimum = 0,
+            Maximum = 5000,
+            Increment = 100,
+            Value = options.DisplayActionDelayMs,
+            Width = 80,
+            BackColor = Color.FromArgb(50, 50, 50),
+            ForeColor = Color.White
+        };
+        var displayDelayPanel = new FlowLayoutPanel { FlowDirection = FlowDirection.LeftToRight, AutoSize = true };
+        displayDelayPanel.Controls.Add(_displayDelayInput);
+        displayDelayPanel.Controls.Add(MakeHelpIcon(_toolTip,
+            "Base delay (ms) before retrying failed display operations.\n" +
+            "Retries double the delay: 300 → 600 → 1200 → 2400.\n" +
+            "5 attempts total. 0 = no retry."));
+        layout.Controls.Add(MakeLabel("Display Retry Delay:"), 0, row);
+        layout.Controls.Add(displayDelayPanel, 1, row++);
 
         // Separator
         layout.Controls.Add(new Label { AutoSize = true, Height = 10 }, 0, row++);
@@ -285,6 +306,7 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
         var displayMode = Enum.TryParse<DisplaySwitchingMode>(_displaySwitchingCombo.SelectedItem?.ToString(), out var dm)
             ? dm : DisplaySwitchingMode.Direct;
         _configWriter.SaveDisplaySwitching(displayMode);
+        _configWriter.SaveDisplayActionDelay((int)_displayDelayInput.Value);
     }
 
     private void OnCancel(object? sender, EventArgs e)
@@ -300,6 +322,8 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
         _autoUpdateCheck.Checked = s.AutoUpdate;
         _includePrereleasesCheck.Checked = s.IncludePrereleases;
 
-        _displaySwitchingCombo.SelectedItem = _configWriter.Read().DisplaySwitching.ToString();
+        var current = _configWriter.Read();
+        _displaySwitchingCombo.SelectedItem = current.DisplaySwitching.ToString();
+        _displayDelayInput.Value = current.DisplayActionDelayMs;
     }
 }

--- a/src/HaPcRemote.Tray/Forms/GeneralTab.cs
+++ b/src/HaPcRemote.Tray/Forms/GeneralTab.cs
@@ -21,6 +21,7 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
     private readonly Label _soundVolumeViewLabel;
     private readonly ComboBox _displaySwitchingCombo;
     private readonly NumericUpDown _displayDelayInput;
+    private readonly CheckBox _useSavedLayoutCheck;
     private readonly IConfigurationWriter _configWriter;
     private readonly int _currentPort;
 
@@ -132,6 +133,23 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
             "5 attempts total. 0 = no retry."));
         layout.Controls.Add(MakeLabel("Display Retry Delay:"), 0, row);
         layout.Controls.Add(displayDelayPanel, 1, row++);
+
+        // Saved layout toggle
+        _useSavedLayoutCheck = new CheckBox
+        {
+            Text = "Use Saved Layout",
+            ForeColor = Color.White,
+            AutoSize = true,
+            Checked = options.UseSavedLayout
+        };
+        var savedLayoutPanel = new FlowLayoutPanel { FlowDirection = FlowDirection.LeftToRight, AutoSize = true };
+        savedLayoutPanel.Controls.Add(_useSavedLayoutCheck);
+        savedLayoutPanel.Controls.Add(MakeHelpIcon(_toolTip,
+            "Try to restore saved monitor positions, resolution, and refresh rate.\n" +
+            "On: use Windows saved layout (QDC_DATABASE_CURRENT), fall back to defaults if unavailable.\n" +
+            "Off: always let Windows pick defaults (QDC_ALL_PATHS)."));
+        layout.Controls.Add(new Label { AutoSize = true }, 0, row);
+        layout.Controls.Add(savedLayoutPanel, 1, row++);
 
         // Separator
         layout.Controls.Add(new Label { AutoSize = true, Height = 10 }, 0, row++);
@@ -307,6 +325,7 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
             ? dm : DisplaySwitchingMode.Direct;
         _configWriter.SaveDisplaySwitching(displayMode);
         _configWriter.SaveDisplayActionDelay((int)_displayDelayInput.Value);
+        _configWriter.SaveUseSavedLayout(_useSavedLayoutCheck.Checked);
     }
 
     private void OnCancel(object? sender, EventArgs e)
@@ -325,5 +344,6 @@ internal sealed class GeneralTab : TabPage, ISettingsTab
         var current = _configWriter.Read();
         _displaySwitchingCombo.SelectedItem = current.DisplaySwitching.ToString();
         _displayDelayInput.Value = current.DisplayActionDelayMs;
+        _useSavedLayoutCheck.Checked = current.UseSavedLayout;
     }
 }

--- a/src/HaPcRemote.Tray/Forms/ModesTab.cs
+++ b/src/HaPcRemote.Tray/Forms/ModesTab.cs
@@ -158,7 +158,7 @@ internal sealed class ModesTab : TabPage, ISettingsTab
             _soloMonitorCombo.Items.Add(new MonitorDropdownItem(null, "(Don't change)"));
             var monitors = await _monitorService.GetMonitorsAsync();
             foreach (var m in monitors)
-                _soloMonitorCombo.Items.Add(new MonitorDropdownItem(m.MonitorId, $"{m.Name} ({m.MonitorId})"));
+                _soloMonitorCombo.Items.Add(new MonitorDropdownItem(m.MonitorId, $"{m.MonitorName} ({m.MonitorId})"));
         }
         catch (Exception ex)
         {

--- a/src/HaPcRemote.Tray/Forms/SettingsForm.cs
+++ b/src/HaPcRemote.Tray/Forms/SettingsForm.cs
@@ -28,8 +28,9 @@ internal sealed class SettingsForm : Form
         MinimumSize = new Size(600, 450);
 
         var settings = TraySettings.Load();
+        var scaleFactor = DeviceDpi / 96f;
         Size = settings.SettingsWidth > 0 && settings.SettingsHeight > 0
-            ? new Size(settings.SettingsWidth, settings.SettingsHeight)
+            ? new Size((int)(settings.SettingsWidth * scaleFactor), (int)(settings.SettingsHeight * scaleFactor))
             : new Size(750, 550);
         StartPosition = FormStartPosition.CenterScreen;
         ShowInTaskbar = true;
@@ -100,8 +101,9 @@ internal sealed class SettingsForm : Form
             e.Cancel = true;
 
             var s = TraySettings.Load();
-            s.SettingsWidth = Width;
-            s.SettingsHeight = Height;
+            var scaleFactor = DeviceDpi / 96f;
+            s.SettingsWidth = (int)(Width / scaleFactor);
+            s.SettingsHeight = (int)(Height / scaleFactor);
             s.Save();
 
             Hide();

--- a/src/HaPcRemote.Tray/Forms/SettingsForm.cs
+++ b/src/HaPcRemote.Tray/Forms/SettingsForm.cs
@@ -65,8 +65,8 @@ internal sealed class SettingsForm : Form
         _gamesTab.SetFooter(_footer);
         _powerTab.SetFooter(_footer);
 
-        Controls.Add(_tabControl);
         Controls.Add(_footer);
+        Controls.Add(_tabControl);
 
         SyncFooter();
     }

--- a/src/HaPcRemote.Tray/Forms/SettingsForm.cs
+++ b/src/HaPcRemote.Tray/Forms/SettingsForm.cs
@@ -16,6 +16,7 @@ internal sealed class SettingsForm : Form
     private readonly GamesTab _gamesTab;
     private readonly PowerTab _powerTab;
     private readonly LogTab _logTab;
+    private readonly DiagnosticsTab _diagnosticsTab;
     private readonly TabFooter _footer;
 
     public SettingsForm(
@@ -51,12 +52,14 @@ internal sealed class SettingsForm : Form
         _gamesTab = new GamesTab(services);
         _powerTab = new PowerTab(services);
         _logTab = new LogTab(logProvider, port);
+        _diagnosticsTab = new DiagnosticsTab(services);
 
         _tabControl.TabPages.Add(_generalTab);
         _tabControl.TabPages.Add(_modesTab);
         _tabControl.TabPages.Add(_gamesTab);
         _tabControl.TabPages.Add(_powerTab);
         _tabControl.TabPages.Add(_logTab);
+        _tabControl.TabPages.Add(_diagnosticsTab);
 
         // Shared footer — buttons swap when the selected tab changes
         _footer = new TabFooter();

--- a/src/HaPcRemote.Tray/TrayWebHost.cs
+++ b/src/HaPcRemote.Tray/TrayWebHost.cs
@@ -108,6 +108,7 @@ internal static class TrayWebHost
         app.MapSteamEndpoints();
         app.MapArtworkDebugEndpoints();
         app.MapPowerEndpoints();
+        app.MapDisplayEndpoints();
 
         return app;
     }

--- a/src/HaPcRemote.Tray/TrayWebHost.cs
+++ b/src/HaPcRemote.Tray/TrayWebHost.cs
@@ -20,6 +20,7 @@ internal static class TrayWebHost
 
         // Logging — file + in-memory (shared with tray log viewer)
         builder.Logging.ClearProviders();
+        builder.Logging.SetMinimumLevel(LogLevel.Trace); // pass everything through; custom providers filter by their own MinimumLevel
         builder.Logging.AddFilter("Microsoft.AspNetCore", LogLevel.Warning);
         builder.Logging.AddProvider(new FileLoggerProvider(ConfigPaths.GetLogFilePath()));
         builder.Logging.AddProvider(logProvider);

--- a/tests/HaPcRemote.Service.Tests/Endpoints/AudioEndpointTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Endpoints/AudioEndpointTests.cs
@@ -10,8 +10,8 @@ public class AudioEndpointTests : EndpointTestBase
 {
     private static readonly List<AudioDevice> TwoDevices =
     [
-        new AudioDevice { Name = "Speakers", IsDefault = true, Volume = 50 },
-        new AudioDevice { Name = "Headphones", IsDefault = false, Volume = 75 }
+        new AudioDevice { Name = "Speakers", IsDefault = true, Volume = 50, IsConnected = true },
+        new AudioDevice { Name = "Headphones", IsDefault = false, Volume = 75, IsConnected = true }
     ];
 
     [Fact]

--- a/tests/HaPcRemote.Service.Tests/Endpoints/SystemStateEndpointTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Endpoints/SystemStateEndpointTests.cs
@@ -10,7 +10,7 @@ public class SystemStateEndpointTests : EndpointTestBase
 {
     private static readonly List<AudioDevice> SpeakersDefault =
     [
-        new AudioDevice { Name = "Speakers", IsDefault = true, Volume = 50 }
+        new AudioDevice { Name = "Speakers", IsDefault = true, Volume = 50, IsConnected = true }
     ];
 
     private void SetupDefaults()

--- a/tests/HaPcRemote.Service.Tests/Services/AudioServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/AudioServiceTests.cs
@@ -8,16 +8,17 @@ namespace HaPcRemote.Service.Tests.Services;
 
 public class AudioServiceTests
 {
-    // SoundVolumeView /scomma with /Columns "Type,Name,Direction,Default,Volume Percent"
-    // Columns: [0] Type, [1] Name, [2] Direction, [3] Default (Console), [4] Volume Percent
+    // SoundVolumeView /scomma with /Columns "Type,Name,Direction,Default,Volume Percent,Status"
+    // Columns: [0] Type, [1] Name, [2] Direction, [3] Default (Console), [4] Volume Percent, [5] Status
     // Type = "Device" for hardware sound card devices; "Application"/"Subunit" for virtual/software entries
     // Default column = "Render" for default render device, empty for non-default
+    // Status = "Active" for connected devices; "Unplugged"/"Disabled"/"Not Present" for disconnected
     // This format matches SoundVolumeView v2.47+ on Windows 10/11
     private const string SampleCsv =
         """
-        Device,Speakers,Render,Render,50.0%
-        Device,Headphones,Render,,75.5%
-        Device,Microphone,Capture,Capture,80.0%
+        Device,Speakers,Render,Render,50.0%,Active
+        Device,Headphones,Render,,75.5%,Active
+        Device,Microphone,Capture,Capture,80.0%,Active
         """;
 
     private readonly ICliRunner _cliRunner = A.Fake<ICliRunner>();
@@ -98,7 +99,7 @@ public class AudioServiceTests
     [Fact]
     public void ParseCsvOutput_CaptureDevicesExcluded()
     {
-        var csv = "Device,Microphone,Capture,Capture,100.0%";
+        var csv = "Device,Microphone,Capture,Capture,100.0%,Active";
         var devices = AudioService.ParseCsvOutput(csv);
 
         devices.ShouldBeEmpty();
@@ -107,7 +108,7 @@ public class AudioServiceTests
     [Fact]
     public void ParseCsvOutput_NoDefaultDevice_AllIsDefaultFalse()
     {
-        var csv = "Device,Speakers,Render,,50.0%";
+        var csv = "Device,Speakers,Render,,50.0%,Active";
         var devices = AudioService.ParseCsvOutput(csv);
 
         devices.Count.ShouldBe(1);
@@ -117,7 +118,7 @@ public class AudioServiceTests
     [Fact]
     public void ParseCsvOutput_VolumeWithoutPercent_ParsesAsZero()
     {
-        var csv = "Device,Speakers,Render,Render,invalid";
+        var csv = "Device,Speakers,Render,Render,invalid,Active";
         var devices = AudioService.ParseCsvOutput(csv);
 
         devices[0].Volume.ShouldBe(0);
@@ -126,7 +127,7 @@ public class AudioServiceTests
     [Fact]
     public void ParseCsvOutput_QuotedFieldsWithCommas_ParsedCorrectly()
     {
-        var csv = "Device,\"Speakers, Front\",Render,Render,50.0%";
+        var csv = "Device,\"Speakers, Front\",Render,Render,50.0%,Active";
         var devices = AudioService.ParseCsvOutput(csv);
 
         devices.Count.ShouldBe(1);
@@ -136,7 +137,7 @@ public class AudioServiceTests
     [Fact]
     public void ParseCsvOutput_WindowsLineEndings_ParsedCorrectly()
     {
-        var csv = "Device,Speakers,Render,Render,50.0%\r\nDevice,Headphones,Render,,75.0%\r\n";
+        var csv = "Device,Speakers,Render,Render,50.0%,Active\r\nDevice,Headphones,Render,,75.0%,Active\r\n";
         var devices = AudioService.ParseCsvOutput(csv);
 
         devices.Count.ShouldBe(2);
@@ -146,10 +147,10 @@ public class AudioServiceTests
     public void ParseCsvOutput_DuplicateDeviceNames_DeduplicatedToFirst()
     {
         var csv = """
-            Device,Speakers,Render,Render,50.0%
-            Device,Speakers,Render,,30.0%
-            Device,Speakers,Render,,20.0%
-            Device,Headphones,Render,,75.0%
+            Device,Speakers,Render,Render,50.0%,Active
+            Device,Speakers,Render,,30.0%,Active
+            Device,Speakers,Render,,20.0%,Active
+            Device,Headphones,Render,,75.0%,Active
             """;
         var devices = AudioService.ParseCsvOutput(csv);
 
@@ -163,10 +164,10 @@ public class AudioServiceTests
     public void ParseCsvOutput_VirtualAudioDevicesExcluded()
     {
         var csv = """
-            Device,Speakers,Render,Render,50.0%
-            Application,Discord,Render,,30.0%
-            Subunit,Steam Streaming Speakers,Render,,0.0%
-            Device,Headphones,Render,,75.0%
+            Device,Speakers,Render,Render,50.0%,Active
+            Application,Discord,Render,,30.0%,Active
+            Subunit,Steam Streaming Speakers,Render,,0.0%,Active
+            Device,Headphones,Render,,75.0%,Active
             """;
         var devices = AudioService.ParseCsvOutput(csv);
 
@@ -211,7 +212,7 @@ public class AudioServiceTests
     public async Task GetCurrentDeviceAsync_NoDefault_ReturnsNull()
     {
         A.CallTo(() => _cliRunner.RunAsync(A<string>._, A<IEnumerable<string>>._, A<int>._))
-            .Returns("Device,Speakers,Render,,50.0%");
+            .Returns("Device,Speakers,Render,,50.0%,Active");
         var service = CreateService();
 
         var device = await service.GetCurrentDeviceAsync();
@@ -272,7 +273,7 @@ public class AudioServiceTests
     public async Task SetVolumeAsync_NoDefaultDevice_ThrowsInvalidOperationException()
     {
         A.CallTo(() => _cliRunner.RunAsync(A<string>._, A<IEnumerable<string>>._, A<int>._))
-            .Returns("Device,Speakers,Render,,50.0%"); // No default device
+            .Returns("Device,Speakers,Render,,50.0%,Active"); // No default device
         var service = CreateService();
 
         await Should.ThrowAsync<InvalidOperationException>(
@@ -300,7 +301,7 @@ public class AudioServiceTests
     public void ParseCsvOutput_NullLikeOnlyCommas_IsSkipped()
     {
         // Line has 5 columns but type is not "Device" — should be excluded
-        var csv = "Application,VoiceMeeter,Render,Render,50.0%";
+        var csv = "Application,VoiceMeeter,Render,Render,50.0%,Active";
         var devices = AudioService.ParseCsvOutput(csv);
 
         devices.ShouldBeEmpty();
@@ -309,7 +310,7 @@ public class AudioServiceTests
     [Fact]
     public void ParseCsvOutput_DeviceNameWithSpaces_ParsedCorrectly()
     {
-        var csv = "Device,Realtek High Definition Audio,Render,Render,60.0%";
+        var csv = "Device,Realtek High Definition Audio,Render,Render,60.0%,Active";
         var devices = AudioService.ParseCsvOutput(csv);
 
         devices.Count.ShouldBe(1);
@@ -319,7 +320,7 @@ public class AudioServiceTests
     [Fact]
     public void ParseCsvOutput_VolumeZeroPercent_ParsesAsZero()
     {
-        var csv = "Device,Speakers,Render,Render,0.0%";
+        var csv = "Device,Speakers,Render,Render,0.0%,Active";
         var devices = AudioService.ParseCsvOutput(csv);
 
         devices.Count.ShouldBe(1);
@@ -329,7 +330,7 @@ public class AudioServiceTests
     [Fact]
     public void ParseCsvOutput_VolumeOneHundredPercent_ParsesAs100()
     {
-        var csv = "Device,Speakers,Render,Render,100.0%";
+        var csv = "Device,Speakers,Render,Render,100.0%,Active";
         var devices = AudioService.ParseCsvOutput(csv);
 
         devices.Count.ShouldBe(1);
@@ -339,7 +340,7 @@ public class AudioServiceTests
     [Fact]
     public void ParseCsvOutput_DeviceNameWithSpecialChars_ParsedCorrectly()
     {
-        var csv = "Device,USB Audio (2.0) [HID],Render,Render,45.0%";
+        var csv = "Device,USB Audio (2.0) [HID],Render,Render,45.0%,Active";
         var devices = AudioService.ParseCsvOutput(csv);
 
         devices.Count.ShouldBe(1);
@@ -363,7 +364,7 @@ public class AudioServiceTests
     [Fact]
     public async Task SetDefaultDeviceAsync_DeviceNameWithSpaces_CallsCliRunnerCorrectly()
     {
-        var csv = "Device,Realtek High Definition Audio,Render,Render,60.0%";
+        var csv = "Device,Realtek High Definition Audio,Render,Render,60.0%,Active";
         A.CallTo(() => _cliRunner.RunAsync(A<string>._, A<IEnumerable<string>>._, A<int>._))
             .Returns(csv);
         var service = CreateService();
@@ -405,5 +406,60 @@ public class AudioServiceTests
             A<string>._,
             A<IEnumerable<string>>.That.IsSameSequenceAs(new[] { "/SetVolume", "Speakers", "100" }),
             A<int>._)).MustHaveHappenedOnceExactly();
+    }
+
+    // ── IsConnected tests ─────────────────────────────────────────────
+
+    [Fact]
+    public void ParseCsvOutput_ActiveDevice_IsConnectedTrue()
+    {
+        var csv = "Device,Speakers,Render,Render,50.0%,Active";
+        var devices = AudioService.ParseCsvOutput(csv);
+
+        devices[0].IsConnected.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ParseCsvOutput_UnpluggedDevice_IsConnectedFalse()
+    {
+        var csv = "Device,Headphones,Render,,0.0%,Unplugged";
+        var devices = AudioService.ParseCsvOutput(csv);
+
+        devices[0].IsConnected.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ParseCsvOutput_DisabledDevice_IsConnectedFalse()
+    {
+        var csv = "Device,Headphones,Render,,0.0%,Disabled";
+        var devices = AudioService.ParseCsvOutput(csv);
+
+        devices[0].IsConnected.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ParseCsvOutput_DisconnectedDevicesIncludedInList()
+    {
+        var csv = """
+            Device,Speakers,Render,Render,50.0%,Active
+            Device,Headphones,Render,,0.0%,Unplugged
+            """;
+        var devices = AudioService.ParseCsvOutput(csv);
+
+        devices.Count.ShouldBe(2);
+        devices[0].Name.ShouldBe("Speakers");
+        devices[0].IsConnected.ShouldBeTrue();
+        devices[1].Name.ShouldBe("Headphones");
+        devices[1].IsConnected.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ParseCsvOutput_MissingStatusColumn_IsConnectedFalse()
+    {
+        // Backward compat: 5-column output (no Status) → IsConnected defaults to false
+        var csv = "Device,Speakers,Render,Render,50.0%";
+        var devices = AudioService.ParseCsvOutput(csv);
+
+        devices[0].IsConnected.ShouldBeFalse();
     }
 }

--- a/tests/HaPcRemote.Service.Tests/Services/ModeServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/ModeServiceTests.cs
@@ -13,12 +13,13 @@ public class ModeServiceTests
     private readonly IMonitorService _monitorService = A.Fake<IMonitorService>();
     private readonly IAppService _appService = A.Fake<IAppService>();
 
-    private ModeService CreateService(Dictionary<string, ModeConfig>? modes = null)
+    private ModeService CreateService(Dictionary<string, ModeConfig>? modes = null, int displayActionDelayMs = 0)
     {
         var options = A.Fake<IOptionsMonitor<PcRemoteOptions>>();
         A.CallTo(() => options.CurrentValue).Returns(new PcRemoteOptions
         {
-            Modes = modes ?? new Dictionary<string, ModeConfig>()
+            Modes = modes ?? new Dictionary<string, ModeConfig>(),
+            DisplayActionDelayMs = displayActionDelayMs
         });
         return new ModeService(options, _audioService, _monitorService, _appService, A.Fake<ILogger<ModeService>>());
     }
@@ -273,6 +274,64 @@ public class ModeServiceTests
         });
 
         await service.ApplyModeAsync("solo");
+
+        A.CallTo(() => _monitorService.SoloMonitorAsync("GSM59A4"))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    // ── ApplyModeAsync — retry logic ──────────────────────────────────
+
+    [Fact]
+    public async Task ApplyModeAsync_TransientFailure_RetriesAndSucceeds()
+    {
+        var callCount = 0;
+        A.CallTo(() => _monitorService.SoloMonitorAsync("GSM59A4"))
+            .Invokes(() =>
+            {
+                callCount++;
+                if (callCount < 3)
+                    throw new InvalidOperationException("SetDisplayConfig failed");
+            });
+
+        var service = CreateService(
+            new Dictionary<string, ModeConfig> { ["retry"] = new() { SoloMonitor = "GSM59A4" } },
+            displayActionDelayMs: 1);
+
+        await service.ApplyModeAsync("retry");
+
+        callCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task ApplyModeAsync_AllRetriesExhausted_Throws()
+    {
+        A.CallTo(() => _monitorService.SoloMonitorAsync(A<string>._))
+            .Throws(new InvalidOperationException("permanent failure"));
+
+        var service = CreateService(
+            new Dictionary<string, ModeConfig> { ["fail"] = new() { SoloMonitor = "GSM59A4" } },
+            displayActionDelayMs: 1);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => service.ApplyModeAsync("fail"));
+        ex.Message.ShouldBe("permanent failure");
+
+        A.CallTo(() => _monitorService.SoloMonitorAsync("GSM59A4"))
+            .MustHaveHappened(5, Times.Exactly);
+    }
+
+    [Fact]
+    public async Task ApplyModeAsync_DelayZero_NoRetry()
+    {
+        A.CallTo(() => _monitorService.SoloMonitorAsync(A<string>._))
+            .Throws(new InvalidOperationException("fail"));
+
+        var service = CreateService(
+            new Dictionary<string, ModeConfig> { ["no-retry"] = new() { SoloMonitor = "GSM59A4" } },
+            displayActionDelayMs: 0);
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => service.ApplyModeAsync("no-retry"));
 
         A.CallTo(() => _monitorService.SoloMonitorAsync("GSM59A4"))
             .MustHaveHappenedOnceExactly();

--- a/tests/HaPcRemote.Service.Tests/Services/UpdateServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/UpdateServiceTests.cs
@@ -94,6 +94,12 @@ public class UpdateServiceTests
     [InlineData("v2.0.0-beta.2", 2, 0, 0, 2)]
     [InlineData("v1.7.0-alpha", 1, 7, 0, 0)]
     [InlineData("v1.2", 1, 2, 0, int.MaxValue)]
+    [InlineData("v1.7.1-rc1", 1, 7, 1, 1)]
+    [InlineData("v1.7.1-rc2", 1, 7, 1, 2)]
+    [InlineData("1.7.1-rc3", 1, 7, 1, 3)]
+    [InlineData("v2.0.0-beta2", 2, 0, 0, 2)]
+    [InlineData("v1.7.1-rc.0", 1, 7, 1, 0)]
+    [InlineData("v1.7.1-rc0", 1, 7, 1, 0)]
     public void ParseVersion_ParsesCorrectly(string tag, int major, int minor, int patch, int revision)
     {
         var v = UpdateService.ParseVersion(tag);
@@ -131,6 +137,17 @@ public class UpdateServiceTests
         rc4.ShouldNotBeNull();
         rc3.ShouldNotBeNull();
         rc4.ShouldBeGreaterThan(rc3);
+    }
+
+    [Fact]
+    public void ParseVersion_DotlessRcOrdering()
+    {
+        var rc2 = UpdateService.ParseVersion("v1.7.1-rc2");
+        var rc1 = UpdateService.ParseVersion("v1.7.1-rc1");
+
+        rc2.ShouldNotBeNull();
+        rc1.ShouldNotBeNull();
+        rc2.ShouldBeGreaterThan(rc1);
     }
 
     // ── ParseVersion via CheckAndApplyAsync ───────────────────────────

--- a/tests/HaPcRemote.Service.Tests/Services/WindowsMonitorServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/WindowsMonitorServiceTests.cs
@@ -16,10 +16,16 @@ public class WindowsMonitorServiceTests
     private readonly IDisplayConfigApi _api = A.Fake<IDisplayConfigApi>();
     private readonly ILogger<WindowsMonitorService> _logger = A.Fake<ILogger<WindowsMonitorService>>();
 
-    private static IOptionsMonitor<PcRemoteOptions> MakeOptions(DisplaySwitchingMode mode = DisplaySwitchingMode.Direct)
+    private static IOptionsMonitor<PcRemoteOptions> MakeOptions(
+        DisplaySwitchingMode mode = DisplaySwitchingMode.Direct,
+        bool useSavedLayout = true)
     {
         var options = A.Fake<IOptionsMonitor<PcRemoteOptions>>();
-        A.CallTo(() => options.CurrentValue).Returns(new PcRemoteOptions { DisplaySwitching = mode });
+        A.CallTo(() => options.CurrentValue).Returns(new PcRemoteOptions
+        {
+            DisplaySwitching = mode,
+            UseSavedLayout = useSavedLayout
+        });
         return options;
     }
 
@@ -1099,5 +1105,73 @@ public class WindowsMonitorServiceTests
 
         A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
             .MustHaveHappenedOnceExactly();
+    }
+
+    // ── UseSavedLayout tests ─────────────────────────────────────────
+
+    private WindowsMonitorService CreateServiceWithSavedLayout(bool useSavedLayout)
+        => new(_api, _logger, MakeOptions(useSavedLayout: useSavedLayout));
+
+    /// <summary>
+    /// Sets up one active + one inactive monitor using standard EDID values.
+    /// Returns the inactive monitor's enable-config paths/modes for use with QDC_DATABASE_CURRENT or QDC_ALL_PATHS.
+    /// Inactive monitor ID = "DEL4321" (targetId 20).
+    /// </summary>
+    private (DISPLAYCONFIG_PATH_INFO[], DISPLAYCONFIG_MODE_INFO[]) SetupSavedLayoutMocks()
+    {
+        SetupOneActiveOneInactive();
+
+        var enablePaths = new[] { MakeInactivePath(Adapter1, 20, 1) };
+        var enableModes = Array.Empty<DISPLAYCONFIG_MODE_INFO>();
+        return (enablePaths, enableModes);
+    }
+
+    [Fact]
+    public async Task EnableMonitor_UseSavedLayout_QueriesDatabaseCurrentFirst()
+    {
+        var service = CreateServiceWithSavedLayout(true);
+        var (paths, modes) = SetupSavedLayoutMocks();
+
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT))
+            .Returns((paths, modes));
+
+        await service.EnableMonitorAsync("DEL4321");
+
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task EnableMonitor_UseSavedLayout_FallsBackOnError87()
+    {
+        var service = CreateServiceWithSavedLayout(true);
+        var (paths, modes) = SetupSavedLayoutMocks();
+
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT))
+            .Throws(new Win32Exception(87));
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS))
+            .Returns((paths, modes));
+
+        await service.EnableMonitorAsync("DEL4321");
+
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS))
+            .MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task EnableMonitor_UseSavedLayoutFalse_SkipsDatabaseCurrent()
+    {
+        var service = CreateServiceWithSavedLayout(false);
+        var (paths, modes) = SetupSavedLayoutMocks();
+
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS))
+            .Returns((paths, modes));
+
+        await service.EnableMonitorAsync("DEL4321");
+
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT))
+            .MustNotHaveHappened();
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS))
+            .MustHaveHappened();
     }
 }

--- a/tests/HaPcRemote.Service.Tests/Services/WindowsMonitorServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/WindowsMonitorServiceTests.cs
@@ -557,10 +557,10 @@ public class WindowsMonitorServiceTests
     }
 
     [Fact]
-    public async Task SoloMonitorAsync_InvalidatesModeIndexesOnTargetPath()
+    public async Task SoloMonitorAsync_UseSavedLayoutFalse_InvalidatesModeIndexesOnTargetPath()
     {
         SetupTwoMonitorConfig();
-        var service = CreateService();
+        var service = CreateServiceWithSavedLayout(false);
 
         DISPLAYCONFIG_PATH_INFO[]? appliedPaths = null;
         A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
@@ -1177,6 +1177,216 @@ public class WindowsMonitorServiceTests
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS))
             .MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task EnableMonitor_UseSavedLayout_PreservesModeIndexes()
+    {
+        var service = CreateServiceWithSavedLayout(true);
+
+        // QDC_ALL_PATHS for GetMonitorsAsync (inactive DEL4321)
+        var allPaths = new[]
+        {
+            MakeActivePath(Adapter1, targetId: 10, sourceId: 0, sourceModeIdx: 0, targetModeIdx: 1),
+            MakeInactivePath(Adapter1, targetId: 20, sourceId: 1),
+        };
+        var allModes = new[]
+        {
+            MakeSourceMode(Adapter1, 0, 3840, 2160, 0, 0),
+            MakeTargetMode(Adapter1, 10, 120000, 1000),
+        };
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS)).Returns((allPaths, allModes));
+
+        // QDC_DATABASE_CURRENT returns DEL4321 with non-INVALID mode indexes
+        var dbPaths = new[]
+        {
+            MakeActivePath(Adapter1, targetId: 20, sourceId: 1, sourceModeIdx: 5, targetModeIdx: 6),
+        };
+        var dbModes = Array.Empty<DISPLAYCONFIG_MODE_INFO>();
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT)).Returns((dbPaths, dbModes));
+
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 10)).Returns(("LG ULTRAGEAR", (ushort)0x6D1E, (ushort)0x59A4));
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 20)).Returns(("Dell U2723QE", (ushort)0xAC10, (ushort)0x4321));
+        A.CallTo(() => _api.GetSourceGdiName(Adapter1, 0)).Returns(@"\\.\DISPLAY1");
+
+        DISPLAYCONFIG_PATH_INFO[]? appliedPaths = null;
+        A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
+            .Invokes((DISPLAYCONFIG_PATH_INFO[] p, DISPLAYCONFIG_MODE_INFO[] _, SetDisplayConfigFlags _) => appliedPaths = p);
+
+        await service.EnableMonitorAsync("DEL4321");
+
+        var targetPath = appliedPaths!.First(p => p.targetInfo.id == 20);
+        targetPath.sourceInfo.modeInfoIdx.ShouldNotBe(DISPLAYCONFIG_PATH_MODE_IDX_INVALID);
+        targetPath.targetInfo.modeInfoIdx.ShouldNotBe(DISPLAYCONFIG_PATH_MODE_IDX_INVALID);
+        targetPath.sourceInfo.modeInfoIdx.ShouldBe(5u);
+        targetPath.targetInfo.modeInfoIdx.ShouldBe(6u);
+    }
+
+    [Fact]
+    public async Task EnableMonitor_UseSavedLayout_FallbackClearsModeIndexes()
+    {
+        var service = CreateServiceWithSavedLayout(true);
+
+        // QDC_DATABASE_CURRENT throws error 87 — fallback to QDC_ALL_PATHS
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT))
+            .Throws(new Win32Exception(ERROR_INVALID_PARAMETER));
+
+        var paths = new[]
+        {
+            MakeActivePath(Adapter1, targetId: 10, sourceId: 0, sourceModeIdx: 0, targetModeIdx: 1),
+            MakeInactivePath(Adapter1, targetId: 20, sourceId: 1),
+        };
+        var modes = new[]
+        {
+            MakeSourceMode(Adapter1, 0, 3840, 2160, 0, 0),
+            MakeTargetMode(Adapter1, 10, 120000, 1000),
+        };
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS)).Returns((paths, modes));
+
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 10)).Returns(("LG ULTRAGEAR", (ushort)0x6D1E, (ushort)0x59A4));
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 20)).Returns(("Dell U2723QE", (ushort)0xAC10, (ushort)0x4321));
+        A.CallTo(() => _api.GetSourceGdiName(Adapter1, 0)).Returns(@"\\.\DISPLAY1");
+
+        DISPLAYCONFIG_PATH_INFO[]? appliedPaths = null;
+        A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
+            .Invokes((DISPLAYCONFIG_PATH_INFO[] p, DISPLAYCONFIG_MODE_INFO[] _, SetDisplayConfigFlags _) => appliedPaths = p);
+
+        await service.EnableMonitorAsync("DEL4321");
+
+        var targetPath = appliedPaths!.First(p => p.targetInfo.id == 20);
+        targetPath.sourceInfo.modeInfoIdx.ShouldBe(DISPLAYCONFIG_PATH_MODE_IDX_INVALID);
+        targetPath.targetInfo.modeInfoIdx.ShouldBe(DISPLAYCONFIG_PATH_MODE_IDX_INVALID);
+    }
+
+    [Fact]
+    public async Task SoloMonitor_UseSavedLayout_PreservesTargetModeIndexes()
+    {
+        var service = CreateServiceWithSavedLayout(true);
+
+        // QDC_ALL_PATHS for GetMonitorsAsync
+        var allPaths = new[]
+        {
+            MakeActivePath(Adapter1, targetId: 10, sourceId: 0, sourceModeIdx: 0, targetModeIdx: 1),
+            MakeActivePath(Adapter1, targetId: 20, sourceId: 1, sourceModeIdx: 2, targetModeIdx: 3),
+        };
+        var allModes = new[]
+        {
+            MakeSourceMode(Adapter1, 0, 3840, 2160, 0, 0),
+            MakeTargetMode(Adapter1, 10, 144000, 1000),
+            MakeSourceMode(Adapter1, 1, 2560, 1440, 3840, 0),
+            MakeTargetMode(Adapter1, 20, 60000, 1000),
+        };
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS)).Returns((allPaths, allModes));
+
+        // QDC_DATABASE_CURRENT returns DEL4321 with non-INVALID mode indexes
+        var dbPaths = new[]
+        {
+            MakeActivePath(Adapter1, targetId: 10, sourceId: 0, sourceModeIdx: 0, targetModeIdx: 1),
+            MakeActivePath(Adapter1, targetId: 20, sourceId: 1, sourceModeIdx: 7, targetModeIdx: 8),
+        };
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT))
+            .Returns((dbPaths, Array.Empty<DISPLAYCONFIG_MODE_INFO>()));
+
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 10)).Returns(("LG ULTRAGEAR", (ushort)0x6D1E, (ushort)0x59A4));
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 20)).Returns(("Dell U2723QE", (ushort)0xAC10, (ushort)0x4321));
+        A.CallTo(() => _api.GetSourceGdiName(Adapter1, 0)).Returns(@"\\.\DISPLAY1");
+        A.CallTo(() => _api.GetSourceGdiName(Adapter1, 1)).Returns(@"\\.\DISPLAY2");
+
+        DISPLAYCONFIG_PATH_INFO[]? appliedPaths = null;
+        A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
+            .Invokes((DISPLAYCONFIG_PATH_INFO[] p, DISPLAYCONFIG_MODE_INFO[] _, SetDisplayConfigFlags _) => appliedPaths = p);
+
+        await service.SoloMonitorAsync("DEL4321");
+
+        var targetPath = appliedPaths!.First(p => p.targetInfo.id == 20);
+        targetPath.sourceInfo.modeInfoIdx.ShouldBe(7u);
+        targetPath.targetInfo.modeInfoIdx.ShouldBe(8u);
+    }
+
+    [Fact]
+    public async Task SoloMonitor_UseSavedLayout_AlwaysClearsDeactivatedPathModeIndexes()
+    {
+        var service = CreateServiceWithSavedLayout(true);
+
+        // QDC_ALL_PATHS for GetMonitorsAsync
+        var allPaths = new[]
+        {
+            MakeActivePath(Adapter1, targetId: 10, sourceId: 0, sourceModeIdx: 0, targetModeIdx: 1),
+            MakeActivePath(Adapter1, targetId: 20, sourceId: 1, sourceModeIdx: 2, targetModeIdx: 3),
+        };
+        var allModes = new[]
+        {
+            MakeSourceMode(Adapter1, 0, 3840, 2160, 0, 0),
+            MakeTargetMode(Adapter1, 10, 144000, 1000),
+            MakeSourceMode(Adapter1, 1, 2560, 1440, 3840, 0),
+            MakeTargetMode(Adapter1, 20, 60000, 1000),
+        };
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS)).Returns((allPaths, allModes));
+
+        // QDC_DATABASE_CURRENT — both paths have valid mode indexes
+        var dbPaths = new[]
+        {
+            MakeActivePath(Adapter1, targetId: 10, sourceId: 0, sourceModeIdx: 4, targetModeIdx: 5),
+            MakeActivePath(Adapter1, targetId: 20, sourceId: 1, sourceModeIdx: 7, targetModeIdx: 8),
+        };
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT))
+            .Returns((dbPaths, Array.Empty<DISPLAYCONFIG_MODE_INFO>()));
+
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 10)).Returns(("LG ULTRAGEAR", (ushort)0x6D1E, (ushort)0x59A4));
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 20)).Returns(("Dell U2723QE", (ushort)0xAC10, (ushort)0x4321));
+        A.CallTo(() => _api.GetSourceGdiName(Adapter1, 0)).Returns(@"\\.\DISPLAY1");
+        A.CallTo(() => _api.GetSourceGdiName(Adapter1, 1)).Returns(@"\\.\DISPLAY2");
+
+        DISPLAYCONFIG_PATH_INFO[]? appliedPaths = null;
+        A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
+            .Invokes((DISPLAYCONFIG_PATH_INFO[] p, DISPLAYCONFIG_MODE_INFO[] _, SetDisplayConfigFlags _) => appliedPaths = p);
+
+        await service.SoloMonitorAsync("DEL4321");
+
+        // Deactivated path (GSM59A4, targetId 10) must have INVALID indexes
+        var deactivatedPath = appliedPaths!.First(p => p.targetInfo.id == 10);
+        deactivatedPath.sourceInfo.modeInfoIdx.ShouldBe(DISPLAYCONFIG_PATH_MODE_IDX_INVALID);
+        deactivatedPath.targetInfo.modeInfoIdx.ShouldBe(DISPLAYCONFIG_PATH_MODE_IDX_INVALID);
+    }
+
+    [Fact]
+    public async Task SoloMonitor_AllPaths_ClearsAllModeIndexes()
+    {
+        var service = CreateServiceWithSavedLayout(false);
+
+        // QDC_ALL_PATHS for both GetMonitorsAsync and BuildSoloConfig
+        var paths = new[]
+        {
+            MakeActivePath(Adapter1, targetId: 10, sourceId: 0, sourceModeIdx: 0, targetModeIdx: 1),
+            MakeActivePath(Adapter1, targetId: 20, sourceId: 1, sourceModeIdx: 2, targetModeIdx: 3),
+        };
+        var modes = new[]
+        {
+            MakeSourceMode(Adapter1, 0, 3840, 2160, 0, 0),
+            MakeTargetMode(Adapter1, 10, 144000, 1000),
+            MakeSourceMode(Adapter1, 1, 2560, 1440, 3840, 0),
+            MakeTargetMode(Adapter1, 20, 60000, 1000),
+        };
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS)).Returns((paths, modes));
+
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 10)).Returns(("LG ULTRAGEAR", (ushort)0x6D1E, (ushort)0x59A4));
+        A.CallTo(() => _api.GetTargetDeviceInfo(Adapter1, 20)).Returns(("Dell U2723QE", (ushort)0xAC10, (ushort)0x4321));
+        A.CallTo(() => _api.GetSourceGdiName(Adapter1, 0)).Returns(@"\\.\DISPLAY1");
+        A.CallTo(() => _api.GetSourceGdiName(Adapter1, 1)).Returns(@"\\.\DISPLAY2");
+
+        DISPLAYCONFIG_PATH_INFO[]? appliedPaths = null;
+        A.CallTo(() => _api.ApplyConfig(A<DISPLAYCONFIG_PATH_INFO[]>._, A<DISPLAYCONFIG_MODE_INFO[]>._, A<SetDisplayConfigFlags>._))
+            .Invokes((DISPLAYCONFIG_PATH_INFO[] p, DISPLAYCONFIG_MODE_INFO[] _, SetDisplayConfigFlags _) => appliedPaths = p);
+
+        await service.SoloMonitorAsync("DEL4321");
+
+        // With UseSavedLayout=false, all paths (target and inactive) must have INVALID indexes
+        var targetPath = appliedPaths!.First(p => p.targetInfo.id == 20);
+        var otherPath = appliedPaths!.First(p => p.targetInfo.id == 10);
+        targetPath.sourceInfo.modeInfoIdx.ShouldBe(DISPLAYCONFIG_PATH_MODE_IDX_INVALID);
+        targetPath.targetInfo.modeInfoIdx.ShouldBe(DISPLAYCONFIG_PATH_MODE_IDX_INVALID);
+        otherPath.sourceInfo.modeInfoIdx.ShouldBe(DISPLAYCONFIG_PATH_MODE_IDX_INVALID);
+        otherPath.targetInfo.modeInfoIdx.ShouldBe(DISPLAYCONFIG_PATH_MODE_IDX_INVALID);
     }
 
     // ── HasSavedLayout ───────────────────────────────────────────────

--- a/tests/HaPcRemote.Service.Tests/Services/WindowsMonitorServiceTests.cs
+++ b/tests/HaPcRemote.Service.Tests/Services/WindowsMonitorServiceTests.cs
@@ -282,7 +282,8 @@ public class WindowsMonitorServiceTests
         await service.GetMonitorsAsync();
         await service.GetMonitorsAsync();
 
-        A.CallTo(() => _api.QueryConfig(A<QueryDisplayConfigFlags>._)).MustHaveHappenedOnceExactly();
+        // Each QueryMonitors call issues QDC_ALL_PATHS + QDC_DATABASE_CURRENT; cache means only one QueryMonitors call
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS)).MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -295,7 +296,8 @@ public class WindowsMonitorServiceTests
         service.InvalidateCache();
         await service.GetMonitorsAsync();
 
-        A.CallTo(() => _api.QueryConfig(A<QueryDisplayConfigFlags>._)).MustHaveHappened(2, Times.Exactly);
+        // Two QueryMonitors calls → two QDC_ALL_PATHS calls
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS)).MustHaveHappened(2, Times.Exactly);
     }
 
     [Fact]
@@ -1137,8 +1139,9 @@ public class WindowsMonitorServiceTests
 
         await service.EnableMonitorAsync("DEL4321");
 
+        // Called once during HasSavedLayout probe (QueryMonitors) and once in BuildEnableConfig
         A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT))
-            .MustHaveHappenedOnceExactly();
+            .MustHaveHappened(2, Times.Exactly);
     }
 
     [Fact]
@@ -1159,7 +1162,7 @@ public class WindowsMonitorServiceTests
     }
 
     [Fact]
-    public async Task EnableMonitor_UseSavedLayoutFalse_SkipsDatabaseCurrent()
+    public async Task EnableMonitor_UseSavedLayoutFalse_UsesDatabaseCurrentOnlyForProbe()
     {
         var service = CreateServiceWithSavedLayout(false);
         var (paths, modes) = SetupSavedLayoutMocks();
@@ -1169,9 +1172,58 @@ public class WindowsMonitorServiceTests
 
         await service.EnableMonitorAsync("DEL4321");
 
+        // QDC_DATABASE_CURRENT is called once from the HasSavedLayout probe, but not from BuildEnableConfig
         A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT))
-            .MustNotHaveHappened();
+            .MustHaveHappenedOnceExactly();
         A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_ALL_PATHS))
             .MustHaveHappened();
+    }
+
+    // ── HasSavedLayout ───────────────────────────────────────────────
+
+    [Fact]
+    public void QueryMonitors_HasSavedLayout_TrueWhenPresentInDatabaseCurrent()
+    {
+        SetupTwoMonitorConfig();
+        var service = CreateService();
+
+        // QDC_DATABASE_CURRENT returns a path for targetId 10 (GSM59A4) only
+        var dbPaths = new[] { MakeActivePath(Adapter1, targetId: 10, sourceId: 0, sourceModeIdx: 0, targetModeIdx: 1) };
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT))
+            .Returns((dbPaths, Array.Empty<DISPLAYCONFIG_MODE_INFO>()));
+
+        var monitors = service.QueryMonitors();
+
+        monitors.First(m => m.MonitorId == "GSM59A4").HasSavedLayout.ShouldBeTrue();
+        monitors.First(m => m.MonitorId == "DEL4321").HasSavedLayout.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void QueryMonitors_HasSavedLayout_FalseWhenDatabaseCurrentThrowsError87()
+    {
+        SetupTwoMonitorConfig();
+        var service = CreateService();
+
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT))
+            .Throws(new Win32Exception(ERROR_INVALID_PARAMETER));
+
+        var monitors = service.QueryMonitors();
+
+        monitors.ShouldAllBe(m => !m.HasSavedLayout);
+    }
+
+    [Fact]
+    public void QueryMonitors_HasSavedLayout_FalseWhenNotInDatabaseCurrent()
+    {
+        SetupTwoMonitorConfig();
+        var service = CreateService();
+
+        // QDC_DATABASE_CURRENT returns empty — no saved layout for any monitor
+        A.CallTo(() => _api.QueryConfig(QueryDisplayConfigFlags.QDC_DATABASE_CURRENT))
+            .Returns((Array.Empty<DISPLAYCONFIG_PATH_INFO>(), Array.Empty<DISPLAYCONFIG_MODE_INFO>()));
+
+        var monitors = service.QueryMonitors();
+
+        monitors.ShouldAllBe(m => !m.HasSavedLayout);
     }
 }


### PR DESCRIPTION
## Summary
- **#121** — Add UseSavedLayout toggle for QDC_DATABASE_CURRENT with fallback to QDC_ALL_PATHS
- **#122** — Expose HasSavedLayout on MonitorInfo to show saved display layout availability
- **#123** — Add display diagnostics tab in settings for debugging display switching issues
- **#125** — Show disconnected audio devices in device list with IsConnected property
- **#129** — Solo monitor dropdown now shows human-readable monitor names
- **#130** — Preserve display mode data from QDC_DATABASE_CURRENT during enable/solo

Closes #118, Closes #120, Closes #124
Closes #121, Closes #122, Closes #123, Closes #125
Closes #129, Closes #130

## Test plan
- [x] 471 unit tests pass (11 new)
- [ ] Verify UseSavedLayout toggle persists across restarts
- [ ] Verify diagnostics tab shows correct QDC data and handles error 87 gracefully
- [ ] Verify disconnected audio devices appear with IsConnected=false
- [ ] Test display switching with UseSavedLayout on and off